### PR TITLE
Fixed digest size references of KIP5 to 32

### DIFF
--- a/kip-0005.md
+++ b/kip-0005.md
@@ -29,7 +29,7 @@ Output: signature associated with that string with some given private key
 `PersonalMessageSigningHash` (Transaction hashes uses `TransactionSigningHash` as key to blake2b) and a digest length of `32`
 2. Schnorr sign the hashed message
 
-In summary: `schnorr_sign(blake2b(raw_message, digest_size=64, key='PersonalMessageSigningHash'), private_key)`
+In summary: `schnorr_sign(blake2b(raw_message, digest_size=32, key='PersonalMessageSigningHash'), private_key)`
 
 ### Why hash a message?
 1. Reduces the size of some arbitrary message to a fixed length hash
@@ -49,7 +49,7 @@ Output: `true` if the signature is valid, `false` otherwise
 1. Hash the raw message in the same way as above for signing
 2. Schnorr verify the signature matches the `public_key` you are testing for
 
-In summary: `schnorr_verify(blake2b(raw_message, digest_size=64, key='PersonalMessageSigningHash'), public_key)`
+In summary: `schnorr_verify(blake2b(raw_message, digest_size=32, key='PersonalMessageSigningHash'), public_key)`
 
 # Sample Implementation
 
@@ -63,7 +63,7 @@ from secp256k1 import PublicKey, PrivateKey
 # some_secret_key (private) and some_public_key (public)
 
 def hash_message(raw_message) -> bytes:
-    message_hash = blake2b(digest_size=64, key=bytes("PersonalMessageSigningHash", "ascii"))
+    message_hash = blake2b(digest_size=32, key=bytes("PersonalMessageSigningHash", "ascii"))
     message_hash.update(raw_message)
     
     return message_hash.digest()


### PR DESCRIPTION
Previously was 64. Actual implementation used 32.