### PR TITLE
Finalize Crescendo details 

### DIFF
--- a/kip-0009.md
+++ b/kip-0009.md
@@ -62,10 +62,10 @@ Storage mass (unlike compute mass) cannot be computed from the standalone transa
 
 To further refine the extended mass formula, the storage mass calculation is adjusted to account for UTXO entries with non-standard script public key sizes (i.e. larger than the typical 35 bytes), thereby capturing the additional persistent storage required.
 
-- **Base Unit Definition**: Define a base UTXO storage unit as `UTXO_UNIT = 100` bytes—derived from the constant parts of a UTXO (63 bytes) plus the maximum standard public key size (35 bytes).
+- **Base Unit Definition**: Define a base UTXO storage unit as `UtxoUnit = 100` bytes—derived from the constant parts of a UTXO (63 bytes) plus the maximum standard public key size (35 bytes).
 
 - **Calculating Plurality**: For a given UTXO entry, compute its plurality as:  
-  $P = \lceil \text{entry.size} / \text{UTXO\_UNIT} \rceil$  
+  $P = \lceil \text{entry.size} / \text{UtxoUnit} \rceil$  
   This value $P$ represents how many standard-sized entries the UTXO effectively occupies. The entry is then treated as $P$ entries, each holding $\text{entry.amount} / P$ KAS.
 
 - **Adjusting the Harmonic Component**: The original harmonic term in the storage mass formula is:  

--- a/kip-0009.md
+++ b/kip-0009.md
@@ -58,6 +58,30 @@ def mass(tx):
 
 Storage mass (unlike compute mass) cannot be computed from the standalone transaction structure, but requires knowing the exact input values, which are only available with full UTXO context (i.e., it requires a *populated* transaction).
 
+#### UTXO plurality adjustment
+
+To further refine the extended mass formula, the storage mass calculation is adjusted to account for UTXO entries with non-standard script public key sizes (i.e. larger than the typical 35 bytes), thereby capturing the additional persistent storage required.
+
+- **Base Unit Definition**: Define a base UTXO storage unit as `UTXO_UNIT = 100` bytes—derived from the constant parts of a UTXO (63 bytes) plus the maximum standard public key size (35 bytes).
+
+- **Calculating Plurality**: For a given UTXO entry, compute its plurality as:  
+  $P = \lceil \text{entry.size} / \text{UTXO\_UNIT} \rceil$  
+  This value $P$ represents how many standard-sized entries the UTXO effectively occupies. The entry is then treated as $P$ entries, each holding $\text{entry.amount} / P$ KAS.
+
+- **Adjusting the Harmonic Component**: The original harmonic term in the storage mass formula is:  
+  $$\sum_{o \in O} \frac{1}{o}$$  
+  For each output, this is now generalized to:  
+  $$\frac{P^2}{o}$$
+
+- **Adjusting the Arithmetic Component**: Similarly, the original arithmetic component:  
+  $$\frac{|I|^2}{\sum_{v \in I} v}$$  
+  is generalized to:  
+  $$\frac{\left(\sum_{i \in I} P_i\right)^2}{\sum_{v \in I} v}$$  
+  where $P_i$ is the plurality of input $i$ and the sum of input values remains unchanged.
+
+This reduction effectively maps larger UTXO entries to the usage of multiple standard units, aligning the storage mass with the actual storage impact of non-standard UTXO sizes.
+
+
 ### Constants
 We suggest setting $C=10^{12}$. Note that transaction input and output values are represented in dworks (also known as sompis), which are the smallest unit of KAS value (a single KAS is equal $10^{8}$ dworks).  
 

--- a/kip-0014.md
+++ b/kip-0014.md
@@ -20,7 +20,7 @@ This hardfork also marks the closure of KIP-1, the Kaspa Rust Rewrite. The perfo
 # Motivation
 The Crescendo Hardfork is a proactive upgrade to the Kaspa network, made possible through RK. With TN11—a testnet operating at 10 BPS—running stably for over a year, the network has demonstrated its readiness for this transition. By increasing capacity and speed, this upgrade positions Kaspa to support anticipated demand from emerging technologies, including smart contract layers enabled via the ongoing based ZK bridge design [1].
 
-All of the changes described in this KIP (excluding KIP-13) have already been implemented and tested in TN11, providing valuable insights into their performance and stability. These results ensure that the proposed modifications are ready for deployment on the Kaspa mainnet.
+All of the changes described in this KIP (excluding KIP-13 and KIP-15) have already been implemented and tested in TN11, providing valuable insights into their performance and stability. These results ensure that the proposed modifications are ready for deployment on the Kaspa mainnet.
 
 # Specification
 ## Consensus changes
@@ -92,6 +92,7 @@ The following details the changes solely related to the bps increase.
 - **KIP-9 (Storage Mass)**: Introduces a storage mass formula to mitigate and regulate UTXO set growth in both organic and adversarial conditions.
 - **KIP-13 (Transient Storage Mass)**: Implements transient storage mass to regulate short-term storage usage.
 - **KIP-10 (Script Engine Enhancements)**: Introduces direct introspection within the script engine, enabling covenants and advanced transaction controls.
+- **KIP-15 (Recursive Canonical Transaction Ordering Commitment)**: Renames header field `AcceptedIDMerkleRoot` to `SequencingCommitment`—computed as `hash(SelectedParent.SequencingCommitment, AcceptedIDMerkleRoot)`, where `AcceptedIDMerkleRoot` is derived using the canonical consensus order of accepted transactions. This change secures transaction ordering for L2 networks—enabling designs like the Accepted Transactions Archival Node (ATAN) (Note: current implementation kept the original field name).
 
 
 ### 3. Additional changes

--- a/kip-0014.md
+++ b/kip-0014.md
@@ -6,8 +6,8 @@ Type: Consensus change (block rate, script engine)
 Author: Michael Sutton <msutton@cs.huji.ac.il>
 Comments-URI: https://research.kas.pa/t/crescendo-hardfork-discussion-thread/279
 created: 2025-01-21
-updated: 2025-01-21
-Status: Draft
+updated: 2025-03-04
+Status: implemented; pending hardfork
 ```
 
 # Abstract
@@ -108,17 +108,12 @@ The `payload` field is already included in the transaction `hash` and `id` in cu
 
 This change enables preliminary second-layer smart contract implementations, leveraging Kaspa for sequencing and data availability without settlement functionality yet. Abuse or spam risks are mitigated by the transient storage regulation introduced in KIP-13. This functionality has already been implemented in RK and activated for TN11 ([pull request](https://github.com/kaspanet/rusty-kaspa/pull/591)).
 
-
-#### Requiring first block parent as Ghostdag selected parent
-
-A new consensus header-validity rule is introduced where the first direct block parent must be the Ghostdag selected parent. This simplifies bringing a witness of the selected chain, particularly for scenarios pre-KIP-6 (which is unplanned for this hardfork).
-
 ## Transitioning strategy
 
 ### General activation strategy
 In Kaspa, the DAA score of a block typically determines when forking rules are activated. However, certain consensus changes can affect the DAA score of the block itself, resulting in circular logic. One notable example is the activation of KIP-4 (sparse DAA window), which modifies how the DAA score is calculated. To avoid this cycle, we propose using the DAA score of the block's selected parent to determine activation. Another scenario where the selected parent's score must be considered instead is the increase in Ghostdag K, since Ghostdag is computed before the DAA score is known.
 
-To simplify implementation, we suggest extending this method to all header-related changes, which includes bps-related changes (excluding coinbase rewards) and the first-parent rule.
+To simplify implementation, we suggest extending this method to all header-related changes, which includes all bps-related changes (excluding coinbase rewards).
 
 For KIPs 9, 10, and 13, as well as payload activation and coinbase reward changes (all block-body-related), we recommend using the usual, more straightforward approach of relying on the DAA score of the block itself.
 

--- a/kip-0014.md
+++ b/kip-0014.md
@@ -109,6 +109,12 @@ The `payload` field is already included in the transaction `hash` and `id` in cu
 
 This change enables preliminary second-layer smart contract implementations, leveraging Kaspa for sequencing and data availability without settlement functionality yet. Abuse or spam risks are mitigated by the transient storage regulation introduced in KIP-13. This functionality has already been implemented in RK and activated for TN11 ([pull request](https://github.com/kaspanet/rusty-kaspa/pull/591)).
 
+#### Runtime sigop counting
+
+To address inefficiencies in static sigop counting, the script engine now counts sigops at runtime. For instance, in scripts supporting additive addresses (cf. KIP-10 for borrower spending details), the previous static scan for `SigVerify` opcodes penalized transactions by charging for sigops regardless of execution. This update tallies only executed sigops, reducing transaction mass and lowering fees, while preserving backward compatibility by allowing transactions to commit to a sigop count that meets or exceeds the runtime value.
+
+
+
 ## Transitioning strategy
 
 ### General activation strategy


### PR DESCRIPTION
Updates the Crescendo KIP details to reflect the final implemented changes:

- Remove the first parent rule
- Add KIP 15
- Add runtime sigop counting 
- Update KIP 9 with UTXO plurality adjustments

Not included: a full breakdown of the approach implemented in https://github.com/kaspanet/rusty-kaspa/pull/643 (which ensures proper pruning samples chain continuity). I feel like this change is too nuanced for the KIP-level, and detailing it here will require an effort which outweighs the value it will provide (given that it's only crucial for the transition phase).   