### PR TITLE
Create kip-0016.md

### DIFF
--- a/kip-0016.md
+++ b/kip-0016.md
@@ -1,0 +1,118 @@
+# KIP-OPCTX: Script v2 Covenant Introspection for Kaspa (Draft)
+
+**Status:** Draft 0.1  
+**Category:** Consensus  
+**Authors:** Gordon Murray (proposer)  
+**Created:** 2025-10-23
+
+## 1. Abstract
+Introduce a minimal, bounded set of **transaction‑context introspection opcodes** under **Script Version 2** that allow locking scripts to **constrain the shape of the spending transaction** (a.k.a. *covenants*). This enables Ergo‑style eUTXO contracts (oracles, AMMs, vaults, auctions) while preserving Kaspa’s simple, parallelizable UTXO validation model.
+
+## 2. Motivation
+Kaspa’s throughput and parallelism benefit from a UTXO model, but today scripts cannot reason about **outputs they create**, limiting on‑chain state machines. A small set of safe, constant‑time introspection ops unlocks practical contracts without an accounts VM or general loops. Goals:
+- Express **deterministic state machines** fully in UTXO (oracle pools, x·y=k AMMs, DLC‑like escrows, vaults).
+- Keep validation **deterministic & bounded**; no global state or unbounded computation.
+- Remain **soft‑forkable** and non‑disruptive to existing scripts.
+
+## 3. Specification
+
+### 3.1 Script Versioning
+- Add **ScriptPublicKey version = 2** ("Script v2").
+- Pre‑activation: version 2 spends are **non‑standard** (policy reject) on mainnet/testnet unless feature‑enabled. Post‑activation: v2 semantics enforced by consensus.
+
+### 3.2 New Opcodes (v2 only)
+All opcodes are **constant time**, **fail on out‑of‑range**, and operate on standard Script numbers/byte strings. Indices are **0‑based** and provided **from the stack** unless noted.
+
+**OP_OUTPUTCOUNT**  
+→ Pushes the number of outputs `N`.
+
+**OP_OUTPUTVALUE**  
+Stack: `...[ idx ]` → `...[ value ]`  
+Pops `idx` and pushes the value (in smallest unit) of output `idx`.
+
+**OP_OUTPUTSCRIPTHASH**  
+Stack: `...[ idx ]` → `...[ hash32 ]`  
+Pops `idx` and pushes `HASH(scriptPubKey_bytes)` of output `idx`.  
+*Hash function:* `BLAKE2b‑256` (see §3.5). The exact serialization of `scriptPubKey_bytes` is the raw locking script bytes of that output.
+
+**OP_INPUTVALUE**  
+Stack: `...[ idx ]` → `...[ value ]`  
+Pops `idx` and pushes the value of the **referenced previous output** for input `idx` (i.e., the input’s value).
+
+**OP_LOCKTIME**  
+Pushes the transaction locktime value (as a Script number). (CLTV context.)
+
+**OP_SEQUENCE**  
+Stack: `...[ input_idx ]` → `...[ sequence ]`  
+Pushes the `nSequence` for the specified input. (CSV support via policy templates.)
+
+**OP_CHECKSIGFROMSTACK** *(optional, see §7 Open Items)*  
+Stack: `...[ msg hash, sig, pub ]` → `...[ true|false ]`  
+Verifies `sig` against `pub` over the provided `msg hash`. Allows signatures on **domain‑separated digests** (e.g., template or state hashes) without recomputing the full tx digest, enabling **template covenants** and **oracle attestations**.
+
+**OP_OUTPUTDATACOMMIT** *(optional – standardized commitment pattern; no tx format change)*  
+Stack: `...[ idx ]` → `...[ commit32 ]`  
+If output `idx` is exactly `OP_RETURN <32‑byte>`, pushes that 32‑byte payload; otherwise **fails**. This gives an ergonomic way to read a 32‑byte state/data commitment from an adjacent zero‑value output without adding new fields to the tx format.
+
+### 3.3 Bounds and Resource Limits
+To harden against DoS, the following **consensus constants** apply to v2 scripts (values adjustable during review; shown here as proposals):
+- `MAX_SCRIPT_SIZE_V2 = 10000` bytes (confirm against current v1 caps).
+- `MAX_STACK_ITEMS_V2 = 1000`, `MAX_STACK_ITEM_SIZE_V2 = 520` bytes (inherit existing unless otherwise specified).
+- **Output inspection cap:** A single script execution may call output‑introspection ops such that the total number of **distinct output indices read** ≤ `MAX_OUTPUTS_INSPECTED_V2 = 4`.
+- **Index bounds:** Access beyond `OP_OUTPUTCOUNT` is a script failure.
+- **Hash cost:** Hash ops accept ≤ 520‑byte items; larger inputs must be composed via bounded `OP_CAT` chunks.
+
+### 3.4 Determinism & Malleability
+- Introspection reads **the fully‑signed spending transaction**; results are deterministic.  
+- Scripts that require **exact output scripts** compare `OP_OUTPUTSCRIPTHASH` to a recomputed template hash (see §3.6) to avoid malleability.
+
+### 3.5 Canonical Script Hash Function
+Define `SCRIPT_HASH(x) = BLAKE2b‑256(x)`. Rationale: consistency with Kaspa’s use of BLAKE2; single canonical hash avoids ambiguity. (If maintainers prefer SHA‑256 for scripting, we can switch; the design is agnostic.)
+
+### 3.6 Template Hashing (for covenants)
+To compare an output’s script to “the same template with a substituted `state_hash`”, define a deterministic **template encoding**:
+- Let `T` be the script bytes containing a single **placeholder** byte‑sequence `PLACEHOLDER = 0xAA…AA` of fixed length (32 bytes).
+- `template_hash(state) = SCRIPT_HASH( replace_all(T, PLACEHOLDER, state) )`.
+- Contracts commit to `SCRIPT_HASH(T)` (the template) and verify:  
+  `OP_OUTPUTSCRIPTHASH outIdx == template_hash(next_state)`.
+
+### 3.7 Standardness (Policy) Rules
+- Before activation, mempool marks v2 spends **non‑standard** (or standard under feature flag on testnet).  
+- After activation, policy caps mirror consensus caps; CPFP/ancestor package rules should allow typical 2‑tx covenant updates.
+
+## 4. Rationale & Alternatives
+- **Why not an accounts VM?** Increases complexity, harms UTXO parallelism; most DeFi/DAO/oracle primitives fit covenants.  
+- **Why not Turing‑complete loops?** Hard to bound; unnecessary for the targeted use‑cases.  
+- **Why `OP_OUTPUTDATACOMMIT` pattern instead of new output field?** Avoids consensus format change; relies on an easily‑auditable `OP_RETURN <32>` convention.
+
+## 5. Backward Compatibility
+Existing v1 scripts unaffected. v2 scripts are gated by Script versioning and only enforced post‑activation.
+
+## 6. Security Considerations
+- **DoS bounds:** explicit caps on script size, stack, and inspected outputs.  
+- **Constant‑time ops:** no variable‑time data‑dependent loops.  
+- **Consensus vs policy:** avoid miner policy divergence by mirroring caps.  
+- **Replay/malleability:** favor template hashing; require exact comparisons rather than parsing target scripts in‑script.
+
+## 7. Open Items
+- Whether to include `OP_CHECKSIGFROMSTACK` in v2 or defer to v3.
+- Final choice of canonical hash (BLAKE2b‑256 vs SHA‑256) for script hashing.
+- Exact numeric values for caps after benchmarking.
+
+## 8. Reference Use‑Cases
+- **Oracle Box:** rolling box requiring same script template and updated `state_hash` = H(price || prev).  
+- **AMM (x·y=k):** covenant checks invariant and recreates pool UTXO with updated reserves.  
+- **Vault:** recovery path with CSV and periodic heartbeat.  
+- **Auctions:** monotonic state with bid escalation and automatic refund.
+
+## 9. Test Plan
+- Unit tests for each opcode (happy/edge paths).  
+- Property tests for bounds (indices, stack, CAT sizes).  
+- Golden vectors for contracts (valid and invalid spends).  
+- Fuzz the interpreter with bounded scripts.  
+- Mempool package tests for 2‑tx covenant updates.
+
+## 10. Reference Implementation Plan
+- Add v2 interpreter path & new opcodes behind a **feature flag**.  
+- Implement template hashing helper in script engine.  
+- Ship a **demo Oracle Box** with vectors; wire testnet policy to accept v2 when flag is set.

--- a/kip-0016.md
+++ b/kip-0016.md
@@ -1,27 +1,27 @@
-# KIP-OPCTX: Script v2 Covenant Introspection for Kaspa (Draft)
+# KIP-0016: Script Covenant Introspection (OPCTX)
 
-**Status:** Draft 0.1  
+**Status:** Draft  
 **Category:** Consensus  
-**Authors:** Gordon Murray (proposer)  
+**Authors:** Gordon Murray  
 **Created:** 2025-10-23
 
 ## 1. Abstract
-Introduce a minimal, bounded set of **transaction‑context introspection opcodes** under **Script Version 2** that allow locking scripts to **constrain the shape of the spending transaction** (a.k.a. *covenants*). This enables Ergo‑style eUTXO contracts (oracles, AMMs, vaults, auctions) while preserving Kaspa’s simple, parallelizable UTXO validation model.
+Introduce a minimal, bounded set of **transaction-context introspection opcodes** that allow locking scripts to **constrain the shape of the spending transaction** (a.k.a. *covenants*). This enables Ergo-style eUTXO contracts (oracles, AMMs, vaults, auctions) while preserving Kaspa’s simple, parallelizable UTXO validation model.
 
 ## 2. Motivation
-Kaspa’s throughput and parallelism benefit from a UTXO model, but today scripts cannot reason about **outputs they create**, limiting on‑chain state machines. A small set of safe, constant‑time introspection ops unlocks practical contracts without an accounts VM or general loops. Goals:
-- Express **deterministic state machines** fully in UTXO (oracle pools, x·y=k AMMs, DLC‑like escrows, vaults).
+Kaspa’s throughput and parallelism benefit from a UTXO model, but today scripts cannot reason about **outputs they create**, limiting on-chain state machines. A small set of safe, constant-time introspection ops unlocks practical contracts without an accounts VM or general loops. Goals:
+- Express **deterministic state machines** fully in UTXO (oracle pools, x·y=k AMMs, DLC-like escrows, vaults).
 - Keep validation **deterministic & bounded**; no global state or unbounded computation.
-- Remain **soft‑forkable** and non‑disruptive to existing scripts.
+- Remain **soft-forkable** and non-disruptive to existing scripts.
 
 ## 3. Specification
 
-### 3.1 Script Versioning
-- Add **ScriptPublicKey version = 2** ("Script v2").
-- Pre‑activation: version 2 spends are **non‑standard** (policy reject) on mainnet/testnet unless feature‑enabled. Post‑activation: v2 semantics enforced by consensus.
+### 3.1 Activation
+OPCTX is added under the **current Script version** via a standard consensus activation (no legacy semantic changes). If the team prefers to gate via `ScriptPublicKey.version`, this can be migrated to a new script version in a follow-up.
 
-### 3.2 New Opcodes (v2 only)
-All opcodes are **constant time**, **fail on out‑of‑range**, and operate on standard Script numbers/byte strings. Indices are **0‑based** and provided **from the stack** unless noted.
+### 3.2 New Opcodes
+_All opcode numbers in this draft are placeholders; final assignment will follow the reserved-opcode guidance (see “Relation to Prior Work”)._  
+All ops are **constant time**, **fail on out-of-range**, and operate on standard Script numbers/byte strings. Indices are **0-based** and provided **from the stack** unless noted.
 
 **OP_OUTPUTCOUNT**  
 → Pushes the number of outputs `N`.
@@ -32,87 +32,118 @@ Pops `idx` and pushes the value (in smallest unit) of output `idx`.
 
 **OP_OUTPUTSCRIPTHASH**  
 Stack: `...[ idx ]` → `...[ hash32 ]`  
-Pops `idx` and pushes `HASH(scriptPubKey_bytes)` of output `idx`.  
-*Hash function:* `BLAKE2b‑256` (see §3.5). The exact serialization of `scriptPubKey_bytes` is the raw locking script bytes of that output.
+Pops `idx` and pushes `SCRIPT_HASH(scriptPubKey_bytes)` of output `idx`.  
+*Hash function:* see §3.6. The `scriptPubKey_bytes` are the raw locking-script bytes of that output.
 
 **OP_INPUTVALUE**  
 Stack: `...[ idx ]` → `...[ value ]`  
-Pops `idx` and pushes the value of the **referenced previous output** for input `idx` (i.e., the input’s value).
+Pops `idx` and pushes the value of the **referenced previous output** for input `idx`.
 
 **OP_LOCKTIME**  
-Pushes the transaction locktime value (as a Script number). (CLTV context.)
+Pushes the transaction locktime value (as a Script number).
 
 **OP_SEQUENCE**  
 Stack: `...[ input_idx ]` → `...[ sequence ]`  
-Pushes the `nSequence` for the specified input. (CSV support via policy templates.)
+Pushes the `nSequence` for the specified input.
 
-**OP_CHECKSIGFROMSTACK** *(optional, see §7 Open Items)*  
-Stack: `...[ msg hash, sig, pub ]` → `...[ true|false ]`  
-Verifies `sig` against `pub` over the provided `msg hash`. Allows signatures on **domain‑separated digests** (e.g., template or state hashes) without recomputing the full tx digest, enabling **template covenants** and **oracle attestations**.
+**OP_CHECKSIGFROMSTACK** *(optional)*  
+Stack: `...[ msg_hash, sig, pub ]` → `...[ true|false ]`  
+Verifies `sig` against `pub` over the provided `msg_hash`. This enables **template-style covenants** and **oracle attestations** without recomputing the entire tx digest.
 
-**OP_OUTPUTDATACOMMIT** *(optional – standardized commitment pattern; no tx format change)*  
-Stack: `...[ idx ]` → `...[ commit32 ]`  
-If output `idx` is exactly `OP_RETURN <32‑byte>`, pushes that 32‑byte payload; otherwise **fails**. This gives an ergonomic way to read a 32‑byte state/data commitment from an adjacent zero‑value output without adding new fields to the tx format.
+### 3.3 Existing Primitives Used (no consensus change)
+This proposal relies on byte/crypto primitives already present in Kaspa Script, such as:
+- `OP_CAT` (byte concatenation)
+- `OP_SHA256`, `OP_BLAKE2B256`
+- `OP_EQUAL`, `OP_EQUALVERIFY`
 
-### 3.3 Bounds and Resource Limits
-To harden against DoS, the following **consensus constants** apply to v2 scripts (values adjustable during review; shown here as proposals):
-- `MAX_SCRIPT_SIZE_V2 = 10000` bytes (confirm against current v1 caps).
-- `MAX_STACK_ITEMS_V2 = 1000`, `MAX_STACK_ITEM_SIZE_V2 = 520` bytes (inherit existing unless otherwise specified).
-- **Output inspection cap:** A single script execution may call output‑introspection ops such that the total number of **distinct output indices read** ≤ `MAX_OUTPUTS_INSPECTED_V2 = 4`.
-- **Index bounds:** Access beyond `OP_OUTPUTCOUNT` is a script failure.
-- **Hash cost:** Hash ops accept ≤ 520‑byte items; larger inputs must be composed via bounded `OP_CAT` chunks.
+### 3.4 Bounds and Resource Limits
+This KIP **inherits the engine’s existing caps** (e.g., max script size, element size, ops per script, stack size).  
+**New bound for covenants:** per script execution, at most **4 distinct output indices** may be inspected via OPCTX ops (tunable during review). Out-of-range access is a script failure. Hash ops must operate on bounded-size items (compose larger inputs via bounded `OP_CAT`).
 
-### 3.4 Determinism & Malleability
-- Introspection reads **the fully‑signed spending transaction**; results are deterministic.  
-- Scripts that require **exact output scripts** compare `OP_OUTPUTSCRIPTHASH` to a recomputed template hash (see §3.6) to avoid malleability.
+### 3.5 Determinism & Malleability
+- Introspection reads **the fully-signed spending transaction**; results are deterministic.  
+- Scripts that require **exact output scripts** should compare `OP_OUTPUTSCRIPTHASH` to a recomputed **template hash** (see §3.7) rather than parsing target scripts in-script.
 
-### 3.5 Canonical Script Hash Function
-Define `SCRIPT_HASH(x) = BLAKE2b‑256(x)`. Rationale: consistency with Kaspa’s use of BLAKE2; single canonical hash avoids ambiguity. (If maintainers prefer SHA‑256 for scripting, we can switch; the design is agnostic.)
+### 3.6 Canonical Script Hash Function
+Define `SCRIPT_HASH(x)` as a single canonical 32-byte hash (e.g., **BLAKE2b-256**). The final choice should align with Kaspa conventions; the design is hash-agnostic.
 
-### 3.6 Template Hashing (for covenants)
-To compare an output’s script to “the same template with a substituted `state_hash`”, define a deterministic **template encoding**:
-- Let `T` be the script bytes containing a single **placeholder** byte‑sequence `PLACEHOLDER = 0xAA…AA` of fixed length (32 bytes).
-- `template_hash(state) = SCRIPT_HASH( replace_all(T, PLACEHOLDER, state) )`.
+### 3.7 Template Hashing (for covenants)
+To compare an output’s script to “the same template with a substituted `state_hash`”, use a deterministic **template encoding**:
+
+- Let `T` be the script bytes containing a single **placeholder** byte-sequence `PLACEHOLDER` (32 bytes).
+- Define `template_hash(state) = SCRIPT_HASH( replace_all(T, PLACEHOLDER, state) )`.
 - Contracts commit to `SCRIPT_HASH(T)` (the template) and verify:  
   `OP_OUTPUTSCRIPTHASH outIdx == template_hash(next_state)`.
 
-### 3.7 Standardness (Policy) Rules
-- Before activation, mempool marks v2 spends **non‑standard** (or standard under feature flag on testnet).  
-- After activation, policy caps mirror consensus caps; CPFP/ancestor package rules should allow typical 2‑tx covenant updates.
+**Note:** `template_hash` is a **convention**, not a new opcode. Scripts compute it with existing hash ops and compare to `OP_OUTPUTSCRIPTHASH`.
 
-## 4. Rationale & Alternatives
-- **Why not an accounts VM?** Increases complexity, harms UTXO parallelism; most DeFi/DAO/oracle primitives fit covenants.  
-- **Why not Turing‑complete loops?** Hard to bound; unnecessary for the targeted use‑cases.  
-- **Why `OP_OUTPUTDATACOMMIT` pattern instead of new output field?** Avoids consensus format change; relies on an easily‑auditable `OP_RETURN <32>` convention.
+### 3.8 Data Commitments
+Kaspa transactions already include a **`payload`** field that applications may use for auxiliary commitments. If Script-level access to the payload becomes desirable, a minimal follow-up (e.g., `OP_TXPAYLOADHASH`) can be proposed separately. No `OP_RETURN` convention is introduced here.
+
+### 3.9 Policy (Standardness) Rules
+- Pre-activation: OPCTX spends are non-standard on mainnet (policy) unless feature-enabled on testnet.  
+- Post-activation: policy caps mirror consensus caps. CPFP/ancestor-package rules should allow typical two-transaction covenant updates.
+
+## 4. Relation to Prior Work
+This KIP complements earlier discussions on **transaction-introspection opcodes** (e.g., KIP-10). Final opcode assignments should be allocated from the **reserved opcode space** defined there. OPCTX adds explicit **output-shape constraints** for covenants and codifies **DoS bounds** for safe validation.
 
 ## 5. Backward Compatibility
-Existing v1 scripts unaffected. v2 scripts are gated by Script versioning and only enforced post‑activation.
+Existing scripts are unaffected. OPCTX introduces new ops via consensus activation; legacy semantics remain unchanged.
 
 ## 6. Security Considerations
-- **DoS bounds:** explicit caps on script size, stack, and inspected outputs.  
-- **Constant‑time ops:** no variable‑time data‑dependent loops.  
-- **Consensus vs policy:** avoid miner policy divergence by mirroring caps.  
-- **Replay/malleability:** favor template hashing; require exact comparisons rather than parsing target scripts in‑script.
+- **DoS bounds:** explicit cap on inspected outputs; existing engine caps retained.  
+- **Constant-time ops:** no variable-time, data-dependent loops.  
+- **Consensus vs policy:** mirror caps to avoid miner policy divergence.  
+- **Replay/malleability:** prefer template hashing with exact comparisons.
 
 ## 7. Open Items
-- Whether to include `OP_CHECKSIGFROMSTACK` in v2 or defer to v3.
-- Final choice of canonical hash (BLAKE2b‑256 vs SHA‑256) for script hashing.
-- Exact numeric values for caps after benchmarking.
+- Whether to include `OP_CHECKSIGFROMSTACK` in this activation or defer.  
+- Final choice of `SCRIPT_HASH` (BLAKE2b-256 vs SHA-256).  
+- Exact numeric value for the “inspected outputs” cap after benchmarking.
 
-## 8. Reference Use‑Cases
+## 8. Reference Use-Cases
 - **Oracle Box:** rolling box requiring same script template and updated `state_hash` = H(price || prev).  
-- **AMM (x·y=k):** covenant checks invariant and recreates pool UTXO with updated reserves.  
+- **AMM (x·y=k):** covenant-checked invariant; pool UTXO recreated with updated reserves.  
 - **Vault:** recovery path with CSV and periodic heartbeat.  
 - **Auctions:** monotonic state with bid escalation and automatic refund.
 
 ## 9. Test Plan
 - Unit tests for each opcode (happy/edge paths).  
-- Property tests for bounds (indices, stack, CAT sizes).  
-- Golden vectors for contracts (valid and invalid spends).  
-- Fuzz the interpreter with bounded scripts.  
-- Mempool package tests for 2‑tx covenant updates.
+- Property tests for bounds (indices, CAT sizes, stack depth).  
+- Golden vectors for contracts (valid/invalid spends).  
+- Fuzzing of the interpreter with bounded scripts.  
+- Mempool package tests for two-transaction covenant updates.
 
 ## 10. Reference Implementation Plan
-- Add v2 interpreter path & new opcodes behind a **feature flag**.  
-- Implement template hashing helper in script engine.  
-- Ship a **demo Oracle Box** with vectors; wire testnet policy to accept v2 when flag is set.
+- Add OPCTX ops behind a **feature flag**.  
+- Implement template-hash utilities in the script engine.  
+- Ship a **demo Oracle Box** with golden vectors; enable on testnet policy for experimentation.
+
+## Relation to KIP-10
+
+This proposal builds on the direction set by [KIP-0010](./kip-0010.md), which introduced the framework and reserved
+opcode space for transaction-introspection extensions. OPCTX stays within that model and contributes three things:
+
+1) **Output-shape introspection:** read-only getters focused on *outputs* and immediate spend context  
+   (`OP_OUTPUTCOUNT`, `OP_OUTPUTVALUE`, `OP_OUTPUTSCRIPTHASH`, plus `OP_INPUTVALUE`, `OP_LOCKTIME`, `OP_SEQUENCE`) to
+   express *covenants* that precisely constrain the child transaction.
+
+2) **Safety bounds made explicit:** a consensus cap on the number of **distinct outputs inspected per execution**
+   (proposed default: ≤4) to harden against DoS, while inheriting all existing engine caps (script size, element size,
+   ops per script, stack size).
+
+3) **Deterministic template comparison:** a clear, hash-based convention for comparing an output’s script against “the
+   same template with an updated state hash” without parsing target scripts in-script.
+
+**Opcode allocation.** Numeric assignments in this draft are placeholders; final values are to be allocated from the
+**reserved opcode space defined by KIP-0010**. If maintainers prefer, OPCTX can also be folded as an extension to
+KIP-0010 rather than a standalone KIP.
+
+| Topic                       | KIP-0010 (baseline)                         | OPCTX (this KIP)                                      |
+|----------------------------|---------------------------------------------|-------------------------------------------------------|
+| Introspection focus        | General tx introspection framework           | **Per-output getters** for covenants                  |
+| Data commitment approach   | Not specified                                | Use existing **transaction payload** (no OP_RETURN)   |
+| DoS safeguards             | Engine caps (implicit)                       | **Explicit cap**: ≤4 distinct outputs inspected       |
+| Script versioning          | Not required                                  | Not required; standard consensus activation           |
+| Malleability handling      | Not specified                                | **Template hashing** convention for script equality   |
+


### PR DESCRIPTION
Abstract:
Introduce a minimal, bounded set of **transaction‑context introspection opcodes** under **Script Version 2** that allow locking scripts to **constrain the shape of the spending transaction** (a.k.a. *covenants*). This enables Ergo‑style eUTXO contracts (oracles, AMMs, vaults, auctions) while preserving Kaspa’s simple, parallelizable UTXO validation model.