### PR TITLE
kip-0017.md

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,0 +1,82 @@
+# KIP-KSM: KaspaScript‑Mini (Typed Covenant DSL) (Draft)
+
+**Status:** Draft 0.1  
+**Category:** Standards (non‑consensus)  
+**Authors:** Gordon Murray (proposer)  
+**Created:** 2025-10-23
+
+## 1. Abstract
+Define **KaspaScript‑Mini (KSM)**, a small, typed, policy‑first DSL that compiles to Script v2 and makes covenant contracts easy to author, analyze, and audit. KSM takes the spirit of Miniscript and ErgoScript and adapts it to Kaspa’s bounded introspection ops.
+
+## 2. Goals
+- Express common covenant patterns with **combinators** (thresholds, timelocks, same‑script, state transitions).  
+- Provide a **static analyzer** that proves resource bounds and enumerates satisfaction paths.  
+- Compile to compact Script v2 with no semantic surprises.
+
+## 3. Language Sketch
+
+### 3.1 Types
+- `Bool`, `Int`, `Bytes`, `StateHash`.
+
+### 3.2 Primitives
+- `pk(pub)`  
+- `after(h|t)` / `older(n)`  
+- `and(a,b)`, `or(a,b)`, `thresh(k, a, b, …)`  
+- **Context**:  
+  `countOutputs() : Int`  
+  `value(i:Int) : Int` *(outputs)*  
+  `scriptHash(i:Int) : Bytes32`  
+  `dataCommit(i:Int) : Bytes32` *(if enabled)*  
+  `inputValue(i:Int) : Int`  
+- **Covenant helpers**:  
+  `sameScript(i)`  
+  `withState(i, StateHash)`  
+  `hash(b:Bytes) : Bytes32`  
+  `checksig(msg:Bytes32, sig:Bytes, pub:Bytes33)`
+
+### 3.3 Example: Oracle Box
+```
+inputs: [self(state), fee_ceiling]
+witness: [price, sig]
+let next = hash(price ++ state);
+all(
+  countOutputs() == 1,
+  sameScript(0),
+  withState(0, next),
+  value(0) >= self.value - fee_ceiling,
+  checksig(domainHash(txid || "ORACLE"), sig, ORACLE_PUB)
+)
+```
+
+### 3.4 AMM Sketch
+```
+# reserves X,Y are encoded in state
+let k    = X * Y;
+let X'   = X + dx - fee(dx);
+let Y'   = k / X';
+require all(
+  sameScript(0),
+  withState(0, hash(encode(X', Y'))),
+  slippage_ok(Y_to_user),
+  conservation_ok()
+)
+```
+
+## 4. Compiler & Analyzer
+- **Compiler:** lowers KSM to Script v2 opcodes; uses template hashing (KIP‑OPCTX §3.6).  
+- **Analyzer:** checks script size, stack depth, and the **max inspected outputs** bound; emits satisfaction graphs for audit.
+
+## 5. Standard Library
+Timelock/CSV combinators, multi‑sig/threshold, vault patterns, auction step, AMM math helpers, oracle aggregation.
+
+## 6. Tooling Deliverables
+- `kaspascript-mini` crate (parser, typechecker, compiler).  
+- TS SDK with builders for each reference contract.  
+- JSON test vectors shared across Rust/TS.
+
+## 7. Backwards Compatibility
+Non‑consensus standard. Multiple independent implementations can exist so long as they compile to equivalent Script v2 bytecode.
+
+## 8. Open Items
+- Exact grammar and encoding for state serialization (CBOR vs protobuf).  
+- Deterministic rounding rules for on‑chain arithmetic helpers.

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,44 +1,48 @@
-# KIP-0017: KaspaScript‑Mini (Typed Covenant DSL) (Draft)
+# KIP-0017: KaspaScript-Mini (Typed Covenant DSL)
 
-**Status:** Draft
-**Category:** Standards (non‑consensus)  
-**Authors:** Gordon Murray
-**Created:** 2025-10-23
+**Status:** Draft  
+**Category:** Standards (non-consensus)  
+**Authors:** Gordon Murray  
+**Created:** 2025-10-24
 
 ## 1. Abstract
-Define **KaspaScript‑Mini (KSM)**, a small, typed, policy‑first DSL that compiles to Script v2 and makes covenant contracts easy to author, analyze, and audit. KSM takes the spirit of Miniscript and ErgoScript and adapts it to Kaspa’s bounded introspection ops.
+Define **KaspaScript-Mini (KSM)**, a small, typed, policy-first DSL that compiles to Kaspa Script using the **OPCTX** introspection primitives introduced by [KIP-0016](./kip-0016.md). KSM makes covenant contracts easy to author, analyze, and audit while staying within Kaspa’s bounded, deterministic eUTXO model. It embraces the **template-hash** convention from KIP-0016 to compare “the same script with an updated state” without parsing target scripts in-script.
 
 ## 2. Goals
-- Express common covenant patterns with **combinators** (thresholds, timelocks, same‑script, state transitions).  
-- Provide a **static analyzer** that proves resource bounds and enumerates satisfaction paths.  
-- Compile to compact Script v2 with no semantic surprises.
+- Express common covenant patterns with **combinators** (thresholds, timelocks, same-script, state transitions).
+- Provide a **static analyzer** that proves resource bounds and enumerates satisfaction paths.
+- Compile to compact Kaspa Script using **OPCTX**; no dependency on a specific script version.
 
 ## 3. Language Sketch
 
 ### 3.1 Types
-- `Bool`, `Int`, `Bytes`, `StateHash`.
+- `Bool`, `Int`, `Bytes`, `StateHash`
 
 ### 3.2 Primitives
-- `pk(pub)`  
-- `after(h|t)` / `older(n)`  
-- `and(a,b)`, `or(a,b)`, `thresh(k, a, b, …)`  
-- **Context**:  
+- **Keys & timelocks:**  
+  `pk(pub)` • `after(h|t)` • `older(n)`
+- **Boolean/thresholds:**  
+  `and(a,b)` • `or(a,b)` • `thresh(k, a, b, …)`
+- **Context (via OPCTX):**  
   `countOutputs() : Int`  
-  `value(i:Int) : Int` *(outputs)*  
-  `scriptHash(i:Int) : Bytes32`  
-  `dataCommit(i:Int) : Bytes32` *(if enabled)*  
-  `inputValue(i:Int) : Int`  
-- **Covenant helpers**:  
-  `sameScript(i)`  
-  `withState(i, StateHash)`  
-  `hash(b:Bytes) : Bytes32`  
+  `value(i:Int) : Int` *(output value)*  
+  `scriptHash(i:Int) : Bytes32` *(SCRIPT_HASH of output script)*  
+  `inputValue(i:Int) : Int`
+- **Covenant helpers:**  
+  `sameScript(i)` *(output i uses the same template as self)*  
+  `withState(i, s:StateHash)` *(output i uses template with state_hash = s)*  
+  `hash(b:Bytes) : Bytes32` *(maps to SCRIPT_HASH from KIP-0016 §3.6)*  
   `checksig(msg:Bytes32, sig:Bytes, pub:Bytes33)`
+
+> Note: KSM does **not** introduce OP_RETURN conventions. If applications use the transaction **payload** for auxiliary commitments, that remains an app-layer choice; Script-level payload access is out of scope here (see KIP-0016 §3.8).
 
 ### 3.3 Example: Oracle Box
 ```
 inputs: [self(state), fee_ceiling]
 witness: [price, sig]
+
 let next = hash(price ++ state);
+
 all(
   countOutputs() == 1,
   sameScript(0),
@@ -54,6 +58,7 @@ all(
 let k    = X * Y;
 let X'   = X + dx - fee(dx);
 let Y'   = k / X';
+
 require all(
   sameScript(0),
   withState(0, hash(encode(X', Y'))),
@@ -63,20 +68,24 @@ require all(
 ```
 
 ## 4. Compiler & Analyzer
-- **Compiler:** lowers KSM to Script v2 opcodes; uses template hashing (KIP‑OPCTX §3.6).  
-- **Analyzer:** checks script size, stack depth, and the **max inspected outputs** bound; emits satisfaction graphs for audit.
+- **Compiler:** lowers KSM to Kaspa Script using OPCTX (KIP-0016 §3.2) and the **template-hash** convention (KIP-0016 §3.7).  
+- **Analyzer:** checks script size, stack depth, and enforces the **cap on distinct outputs inspected per execution** (as defined in KIP-0016). Emits satisfaction graphs for auditability.
 
 ## 5. Standard Library
-Timelock/CSV combinators, multi‑sig/threshold, vault patterns, auction step, AMM math helpers, oracle aggregation.
+Timelock/CSV combinators, multi-sig/threshold, vault patterns, auction step, AMM math helpers, oracle aggregation utilities.
 
 ## 6. Tooling Deliverables
 - `kaspascript-mini` crate (parser, typechecker, compiler).  
-- TS SDK with builders for each reference contract.  
-- JSON test vectors shared across Rust/TS.
+- TypeScript SDK with builders for each reference contract.  
+- Shared JSON test vectors for Rust/TS implementations.
 
 ## 7. Backwards Compatibility
-Non‑consensus standard. Multiple independent implementations can exist so long as they compile to equivalent Script v2 bytecode.
+Non-consensus standard. Multiple independent implementations can coexist as long as they compile to equivalent Kaspa Script bytecode leveraging OPCTX. Contracts produced by KSM run on nodes that support the OPCTX activation from KIP-0016.
 
-## 8. Open Items
+## 8. Relation to KIP-0016
+KSM is an **appendix-level standard** that targets OPCTX. It does not change consensus and inherits KIP-0016’s security model: bounded introspection, deterministic semantics, and the template-hash approach to avoid malleability.
+
+## 9. Open Items
 - Exact grammar and encoding for state serialization (CBOR vs protobuf).  
-- Deterministic rounding rules for on‑chain arithmetic helpers.
+- Deterministic rounding rules for on-chain arithmetic helpers.  
+- Formalization of `sameScript`/`withState` lowering patterns for analyzability.

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,8 +1,8 @@
-# KIP-KSM: KaspaScript‑Mini (Typed Covenant DSL) (Draft)
+# KIP-0017: KaspaScript‑Mini (Typed Covenant DSL) (Draft)
 
-**Status:** Draft 0.1  
+**Status:** Draft
 **Category:** Standards (non‑consensus)  
-**Authors:** Gordon Murray (proposer)  
+**Authors:** Gordon Murray
 **Created:** 2025-10-23
 
 ## 1. Abstract


### PR DESCRIPTION
Abstract
Define **KaspaScript-Mini (KSM)**, a small, typed, policy-first DSL that compiles to Kaspa Script using the **OPCTX** introspection primitives introduced by [KIP-0016](./kip-0016.md). KSM makes covenant contracts easy to author, analyze, and audit while staying within Kaspa’s bounded, deterministic eUTXO model. It embraces the **template-hash** convention from KIP-0016 to compare “the same script with an updated state” without parsing target scripts in-script.