### PR TITLE
KIP-21: Partitioned sequencing commitment with O(activity) proving

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Kaspa Improvement Proposals (KIPs) describe standard proposals for the Kaspa net
 | [13](kip-0013.md) | Consensus | Transient Storage Handling | Michael Sutton, coderofstuff | Active |
 | [14](kip-0014.md) | Consensus | The Crescendo Hardfork | Michael Sutton | Active |
 | [15](kip-0015.md) | Consensus | Canonical Transaction Ordering and Sequencing Commitments | Mike Zak, Ro Ma | Active |
+| [21](kip-0021.md) | Consensus, Chain-Block UTXO Validation | Partitioned Sequencing Commitment with O(activity) Proving | Michael Sutton, Maxim Biryukov, Hans Moog | Implemented and activated in TN10 |

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -202,7 +202,7 @@ Domain tags:
 
 For convenience, `H_seq(x, y)` means `H_seq(x || y)` where `x` and `y` are 32-byte values.
 
-#### 4.1 Primitive Encodings and Transaction Digest
+#### 4.1 Primitive Encodings
 
 Primitive encodings:
 
@@ -213,16 +213,10 @@ Primitive encodings:
 
 `blue_work_encoding` matches the consensus hashing semantics used by `rusty-kaspa` header hashing (`write_blue_work`).
 
-Transaction digest:
-
-```
-tx_digest(tx) = seq_commit_tx_digest(tx.id, tx.version)
-```
-
 #### 4.2 Per-Lane Block Activity Digest
 
 Intuition: This section defines what happened for the lane identified by `lane_id` in block `B` as a single hash. We do this by
-committing to (i) the transaction digest and (ii) a block-local index (`merge_idx`) which lets upper layers
+committing to (i) the transaction ID and version and (ii) a block-local index (`merge_idx`) which lets upper layers
 reconstruct global order when needed.
 
 Let `AcceptedTxList(B)` be the ordered list of all accepted transactions in chain block `B`, in canonical acceptance order. The sequence starts with the selected-parent coinbase transaction, followed by accepted non-coinbase transactions in consensus order.
@@ -240,7 +234,12 @@ For a lane identifier `lane_id`, define `LaneTxList(B, lane_id)` to be the list 
 Define the per-lane activity leaf for each transaction:
 
 ```
-activity_leaf(tx) = H_activity_leaf(tx_digest(tx) || le_u32(merge_idx(tx)))
+activity_leaf(tx) =
+    H_activity_leaf(
+        tx.id
+        || le_u16(tx.version)
+        || le_u32(merge_idx(tx))
+    )
 ```
 
 Define the per-lane activity digest as a Merkle root over the leaf list:
@@ -252,7 +251,7 @@ activity_digest_lane(B, lane_id) = MerkleRoot([activity_leaf(tx) for tx in LaneT
 Merkle-root semantics match the sequencing commitment Merkle-root behavior specified by this KIP:
 
 * Empty list root is `ZERO_HASH` (32 zero bytes).
-* Single entry root is `H_seq(entry, ZERO_HASH)` (not the entry itself).
+* Single entry root is the entry itself.
 * Internal nodes are `H_seq(left, right)`.
 
 #### 4.3 Tip Update Hash

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -567,7 +567,7 @@ The heap is a cache/hint layer only; canonical correctness is defined by persist
 
 All index mutations (insert/update/delete in `LastTouchByScore`) are part of `SeqCommitDiff` and are reversible under reorg.
 
-#### 9.4 IBD Bootstrap at Pruning Point (Normative Guidance)
+#### 9.4 IBD Bootstrap at Pruning Point (Normative)
 
 IBD from the pruning point (PP) must provide enough sequencing-commitment state for a new node to continue normal chain-block processing from PP onward.
 
@@ -583,7 +583,7 @@ From that verified PP state, a node processes subsequent chain blocks by the sam
 
 Operational note:
 
-* Implementations should retain the PP active set analogously to PP UTXO-set retention, and when PP advances, update it by advancing over sequencing-commitment diffs from the old PP to the new PP.
+* Implementations should retain the PP active set analogously to PP UTXO-set retention, and when PP advances, update it by advancing over sequencing-commitment diffs from the old PP to the new PP. This is required so IBD syncers can provide the minimum PP data listed above to syncing nodes.
 * Alternatively, an implementation may reconstruct the PP active set in linear time using the optional persistent witness-store structure (Section 11).
 
 ## Informative: Proving and Witness Operations
@@ -621,7 +621,7 @@ The lane-diff witness size is proportional to lane activity between anchors, so 
 
 Including $MergesetContextHash(B)$ in touched lane-tip updates is what makes accepting-block clock/context available on the lane-local path without forcing per-block global sequencing commitment processing.
 
-Miner payloads remain a block-level commitment ($MinerPayloadRoot(B)$). Apps that rely on this data still track block-level witnesses across intermediate chain blocks.
+Miner payloads remain a block-level commitment ( $MinerPayloadRoot(B)$ ). Apps that rely on this data still track block-level witnesses across intermediate chain blocks.
 
 #### 10.3 Reactivated Lane Proof Pattern
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -65,6 +65,35 @@ The shortest way to think about the construction is:
 
 This yields one header commitment for consensus, while preserving lane-local witnesses for `O(activity)` proving between anchors.
 
+The following diagram illustrates the underlying proving scheme:
+
+```
+Selected-parent SeqCommit chain (global, deep):
+
+  SeqCommit(B0) -> SeqCommit(B1) -> SeqCommit(B2) -> SeqCommit(B3) -> ... -> SeqCommit(BN)
+       |               |               |               |                               |
+       v               v               v               v                               v
+   ActiveLanes0    ActiveLanes1    ActiveLanes2    ActiveLanes3                   ActiveLanesN
+
+For one target lane (lane = L), proofs only touch the two anchors and lane-local transition:
+
+  anchor start                                                      anchor end
+      |                                                                 |
+      v                                                                 v
+  include lane_key(L) under ActiveLanes0                    include lane_key(L) under ActiveLanesN
+      |                                                                 ^
+      |                                                                 |
+      +------------ compressed lane-local tip transition ---------------+
+                   lane_tip(L, B0)  =>  ... lane activity ...  =>  lane_tip(L, BN)
+```
+
+Interpretation:
+
+- The global chain remains linear and deep.
+- Lane proving uses two global anchors plus a lane-local compressed transition.
+- Proof size tracks lane activity between anchors, rather than all intermediate chain blocks.
+
+
 ## Specification
 
 This specification is written in two passes so readers can first follow the state transition mechanics and then see exactly how that state is committed in the header:

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -367,12 +367,6 @@ The sparse Merkle root over all active leaves is the active lanes root:
 ActiveLanesRoot(B) = SMT_Root({ lane_key(lane_id) -> leaf_hash(lane_id) | lane_id in ActiveLanes })
 ```
 
-Consensus sets:
-
-```
-B.header.accepted_id_merkle_root = SeqCommit(B)
-```
-
 #### 6.4 Sparse Merkle Tree Definition (Normative)
 
 This KIP defines `SMT_Root` as a fixed-depth (256) sparse Merkle tree:
@@ -488,6 +482,12 @@ Notes:
 * `SeqCommit(B)` is chained through selected-parent ancestry (KIP-15 style recurrence).
 * `SeqStateRoot(B)` is not directly exposed in the header; it is committed by `SeqCommit(B)`.
 * `ActiveLanesRoot(B)` is not directly exposed in the header; it is committed by `SeqStateRoot(B)` and therefore by `SeqCommit(B)`.
+
+Post-activation, consensus sets:
+
+```
+B.header.accepted_id_merkle_root = SeqCommit(B)
+```
 
 ### 7. Script Semantics
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -528,7 +528,6 @@ Rationale:
 For each mergeset block `X`:
 
 * Let `payload_bytes(X)` be the raw payload bytes of the coinbase transaction of `X`.
-* Consensus rule update: for coinbase payload bytes, the legacy hard size limit is relaxed for miner-payload use, and the payload segment above that legacy limit is charged via transient mass.
 
 For each mergeset block `X`, define:
 
@@ -721,7 +720,7 @@ Within the Covenants++ workstream, it complements KIP-16, KIP-17, and KIP-20. TN
 ## Backward Compatibility
 
 * This KIP is a consensus-changing hard fork: post-activation blocks are not consensus-compatible with nodes that do not implement these rules.
-* Post-activation, `accepted_id_merkle_root` follows `SeqCommit(B)` as defined here, coinbase payload bytes above the legacy hard size limit are admitted and charged via transient mass, and `OpChainblockSeqCommit` consumes this commitment path.
+* Post-activation, `accepted_id_merkle_root` follows `SeqCommit(B)` as defined here, and `OpChainblockSeqCommit` consumes this commitment path.
 
 ## Why SMT
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -622,13 +622,27 @@ Implementations must also support selected-parent reorgs without changing the re
 
 IBD from the pruning point (PP) must provide enough sequencing-commitment state for a new node to continue normal chain-block processing from PP onward.
 
-At PP, an implementation must have (or reconstruct) the following minimum data:
+At PP, a node must have (or reconstruct) the following minimum data:
 
-* Full active-lane leaf data at PP (`lane_id`, `lane_tip_hash`, `last_touch_blue_score` for every active lane), sufficient to reconstruct `ActiveLanesRoot(PP)` in full.
+* Full active-lane state at PP, sufficient to reconstruct `ActiveLanesRoot(PP)` in full. For each active entry this includes the SMT key, lane tip hash, and last-touch blue score.
+* A selected-parent-chain header segment ending at PP and extending far enough below PP to include `InactivityShortcutBlock(PP)`.
+* `PayloadAndContextDigest(PP)`, or `MergesetContextHash(PP)` and `MinerPayloadRoot(PP)` from which to recompute it.
 * `SeqCommit(parent(PP))` (equivalently, `PP` selected-parent `accepted_id_merkle_root`).
-* `MergesetContextHash(PP)` and `MinerPayloadRoot(PP)` (or equivalent raw data to deterministically recompute them).
 
-These are sufficient to verify `SeqStateRoot(PP)` and then verify `PP.accepted_id_merkle_root = SeqCommit(PP)` by the recurrence in Section 6.7.
+The header segment is required not only to verify `InactivityShortcut(PP)`, but also to derive shortcut values for chain blocks processed immediately after PP, until locally processed blocks are deep enough to supply the shortcut path without relying on the imported boundary segment. This coincides with the selected-parent-chain header segment required for `OpChainblockSeqCommit` access around the pruning-point boundary; that accessor-specific requirement is specified in [Seqcommit Accessor](kip-0021/seqcommit-accessor.md).
+
+Using the header segment, the node derives `InactivityShortcutBlock(PP)` by Section 5.4 and resolves `InactivityShortcut(PP)`. The data above are then sufficient to verify:
+
+```
+ActivityRoot(PP) =
+    H_activity_root(InactivityShortcut(PP), ActiveLanesRoot(PP))
+
+SeqStateRoot(PP) =
+    H_seq(ActivityRoot(PP), PayloadAndContextDigest(PP))
+
+PP.accepted_id_merkle_root =
+    H_seq(SeqCommit(parent(PP)), SeqStateRoot(PP))
+```
 
 From that verified PP state, a node processes subsequent chain blocks by the same consensus state-transition rules in Sections 5-8.
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -11,7 +11,7 @@ Created: 2026-02-17
 
 This KIP replaces the current per-chain-block linear sequencing commitment recurrence with a partitioned sequencing commitment scheme.
 
-Instead of committing to all accepted transactions in every chain block as one global append-only stream, consensus maintains a commitment over the tips of active application lanes. Each active lane has its own recursive tip hash and last-touch blue score. Global order remains reconstructible via `merge_idx` (Section 10.1), but is no longer directly committed as one monolithic per-block list. The block header continues to expose a single `accepted_id_merkle_root` value (consumed by `OpChainblockSeqCommit`), but post-activation it commits to (i) the active-lanes sparse Merkle tree (SMT) root and (ii) per-block context and mergeset miner payloads, chained through selected-parent recursion.
+Instead of committing to all accepted transactions in every chain block as one global append-only stream, consensus maintains a commitment over the tips of active application lanes (defined in Section 1). Each active lane has its own recursive tip hash and last-touch blue score. Global order remains reconstructible via `merge_idx` (Section 10.1), but is no longer directly committed as one monolithic per-block list. The block header continues to expose a single `accepted_id_merkle_root` value (consumed by `OpChainblockSeqCommit`), but post-activation it commits to (i) the active-lanes sparse Merkle tree (SMT) root and (ii) per-block context and mergeset miner payloads, chained through selected-parent recursion.
 
 The primary goal is prover cost proportional to relevant lane activity (`O(activity)`) for zk proving systems that consume chain-block sequencing commitments as anchors, while preserving global anchoring and enabling bounded-memory eviction of inactive lanes. In addition, `SeqStateRoot(B)` commits block-level context needed by based zk systems (timestamp, DAA score, and blue score) and mergeset miner payloads, under the same chained commitment, and touched lane-tip updates include the same context hash.
 
@@ -55,7 +55,7 @@ Sections explicitly marked `(Informative)` explain rationale or intended use and
 The shortest way to think about the construction is:
 
 1. start from the accepted transaction sequence `AcceptedTxList(B)` (selected-parent coinbase first);
-2. extract lane IDs (`lane_id_bytes`) from transactions;
+2. extract lane IDs (`lane_id`) from transactions;
 3. group transactions by lane;
 4. compute one `activity_digest_lane(B)` per touched lane, with `merge_idx` committed per tx;
 5. update each touched lane tip recursively (existing lane uses previous lane tip; re-appearing lane after purge anchors to `SeqCommit(parent(B))`);
@@ -128,23 +128,18 @@ This keeps the mechanism consensus-native and deterministic with current transac
 
 #### 2.1 Canonical Lane ID Encoding (Normative)
 
-This KIP defines a canonical lane identifier byte string `lane_id_bytes`.
+In this KIP, `lane_id` denotes the transaction `subnetwork_id`.
 
-Current encoding (subnetwork lanes):
-
-* Let `subnetwork_id` be the canonical 20-byte `tx.subnetwork_id`.
-* Define `lane_id_bytes = subnetwork_id` (20 bytes, no padding).
+It is a 20-byte value and is treated as an opaque lane identifier at this layer.
 
 System-reserved subnetwork IDs:
 
 * IDs of the form `x || 0x00..0x00` (one first byte `x`, followed by 19 zeros) are reserved for system usage by consensus.
 * This reserved set includes the currently hardcoded subnet IDs.
 
-Consensus nodes treat `lane_id_bytes` as opaque identifiers at this layer.
-
 Rationale for keying:
 
-* The committed SMT key is `lane_key(lane) = H_lane_key(lane_id_bytes(lane))` (Section 6.1).
+* The committed SMT key is `lane_key(lane) = H_lane_key(lane_id(lane))` (Section 6.1).
 * Because key width is normalized by `H_lane_key`, zero-padding lane IDs is unnecessary.
 * This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs, including vProg-derived lane identifiers.
 
@@ -250,14 +245,14 @@ Merkle-root semantics match the sequencing commitment Merkle-root behavior speci
 For lane `lane` in accepting block `B`, define a recursive update step:
 
 ```
-TipUpdateHash(parent_ref, lane_id_bytes(lane), activity_digest, MergesetContextHash(B)) =
-    H_lane_tip(parent_ref || lane_id_bytes(lane) || activity_digest || MergesetContextHash(B))
+TipUpdateHash(parent_ref, lane_id(lane), activity_digest, MergesetContextHash(B)) =
+    H_lane_tip(parent_ref || lane_id(lane) || activity_digest || MergesetContextHash(B))
 ```
 
 where:
 
 * `parent_ref` is either the previous lane tip hash (if lane is already active) or a global anchor (Section 5.2).
-* `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+* `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
 * `activity_digest` is `activity_digest_lane(B)`.
 * `MergesetContextHash(B)` is defined in Section 6.5.1.
 
@@ -294,7 +289,7 @@ For each `lane in Touched(B)`:
 3. Else:
 
    * `parent_ref = SeqCommit(parent(B))`
-4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id_bytes(lane), activity_digest_lane(B), ctx_hash_B)`.
+4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id(lane), activity_digest_lane(B), ctx_hash_B)`.
 5. Set:
 
    * `ActiveLanes[lane].lane_tip_hash = tip_next`
@@ -337,10 +332,10 @@ At a high level:
 Define the sparse-Merkle key for lane `lane`:
 
 ```
-lane_key(lane) = H_lane_key(lane_id_bytes(lane))    // 32-byte key
+lane_key(lane) = H_lane_key(lane_id(lane))    // 32-byte key
 ```
 
-where `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+where `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
 
 #### 6.2 Leaf Value
 
@@ -348,14 +343,14 @@ Leaf payload for lane `lane`:
 
 ```
 leaf_payload_lane =
-    lane_id_bytes(lane)
+    lane_id(lane)
     || lane_tip_hash
     || le_u64(last_touch_blue_score)
 ```
 
 where:
 
-* `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+* `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
 * `lane_tip_hash` and `last_touch_blue_score` are taken from `ActiveLanes[lane]`.
 
 Leaf hash:
@@ -512,7 +507,7 @@ IBD from the pruning point (PP) must provide enough sequencing-commitment state 
 
 At PP, an implementation must have (or reconstruct) the following minimum data:
 
-* Full active-lane leaf data at PP (`lane_id_bytes`, `lane_tip_hash`, `last_touch_blue_score` for every active lane), sufficient to reconstruct `ActiveLanesRoot(PP)` in full.
+* Full active-lane leaf data at PP (`lane_id`, `lane_tip_hash`, `last_touch_blue_score` for every active lane), sufficient to reconstruct `ActiveLanesRoot(PP)` in full.
 * `SeqCommit(parent(PP))` (equivalently, `PP` selected-parent `accepted_id_merkle_root`).
 * `MergesetContextHash(PP)` and `MinerPayloadRoot(PP)` (or equivalent raw data to deterministically recompute them).
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -726,11 +726,11 @@ Within the Covenants++ workstream, it complements KIP-16, KIP-17, and KIP-20. TN
 
 ## Why SMT
 
-Sparse authenticated map vs dense tree: this commitment tracks a sparse key-value map over lane IDs, with updates driven by touched/purged lanes. Dense tree representations are not practical here because diff/update work scales with global key-space structure rather than with per-block mutations.
+The active-lanes commitment is a sparse authenticated map from `lane_key(lane_id)` to active-lane leaf hash. The map is sparse because only recently active lanes are present, while keys live in a 256-bit hash-derived space.
 
-SMT vs Patricia: both SMT and Patricia-style sparse tries are viable and have similar asymptotic update properties (`O(mutations)` per block). This KIP chooses SMT for operational simplicity and proof regularity: implementation is simpler, and fixed-shape proofs are more uniform for verifier behavior and zk-circuit design.
+SMT is chosen because it gives deterministic bitwise keying over fixed hash-derived keys and simple inclusion/exclusion relations. Patricia-style tries would also be possible, but they compress shared internal paths, which significantly complicates the committed structure and implementation.
 
-Implementation note: storage/IO overhead can be reduced with known sparse-tree optimization techniques (see [6]).
+The collapsed single-leaf rule in Section 6.4 keeps the easy and most relevant part of that optimization: when a subtree contains only one active key, the subtree commits directly to that key and leaf hash instead of carrying empty siblings down to depth 256. Since lane keys are hash-distributed and the subnetwork rules restrict the preimage space, this gives the same practical witness-size benefit expected from Patricia-style compression for normal active sets, while avoiding compressed interim shared paths. Under the usual random-oracle intuition for the key bits, where `n = |ActiveLanes|`, the relevant shared-prefix length is governed by `n`, so witnesses normally contain `O(log n)` non-empty branching hashes rather than one hash per key bit; see [6].
 
 ## References
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -23,7 +23,7 @@ Under the current linear per-block recurrence, proving correctness for lane-spec
 
 By committing to lane tips (and lane-local block activity digests) rather than to the entire global stream, this KIP makes lane proofs proportional to lane activity, enabling `O(activity)`-style proving.
 
-This scheme does not assume a fixed bound on the number of active lanes. In the worst case, each transaction may belong to a distinct lane. However, the committed active set is bounded by the number of lanes touched within the activity window `F`, and `F` is strictly less than pruning depth. Therefore, node storage is not increased asymptotically: the “hot” commitment set scales with recent activity, not with historical diversity of lane IDs.
+This scheme does not assume a fixed bound on historical lane-ID diversity. The committed active set is bounded by recent admitted lane activity within the activity window `F`, and `F` is strictly less than pruning depth. Therefore, node storage is not increased asymptotically: the “hot” commitment set scales with recent activity, not with historical diversity of lane IDs.
 
 ## Goals
 
@@ -120,9 +120,9 @@ This specification is written in two passes so readers can first follow the stat
 
 For this KIP, lanes are extracted from accepted transactions as follows:
 
-* For each accepted transaction `tx`, the lane selector is `tx.subnetwork_id`.
+* For each accepted transaction `tx`, `lane_id(tx) = tx.subnetwork_id`.
 * This includes the selected-parent coinbase transaction, which uses the dedicated coinbase subnetwork ID.
-* This KIP does not merge built-in/native IDs into a single SYS lane; native, coinbase, and registry subnet IDs are mapped as distinct lanes.
+* This KIP does not merge system lanes into a single SYS lane; each valid subnetwork ID maps to its own lane.
 
 This keeps the mechanism consensus-native and deterministic with current transaction structure. Future KIPs may define additional lane families and lane-local update rules (e.g., vProg-based CD commitments), while reusing the same outer commitment machinery.
 
@@ -130,18 +130,33 @@ This keeps the mechanism consensus-native and deterministic with current transac
 
 In this KIP, `lane_id` denotes the transaction `subnetwork_id`.
 
-It is a 20-byte value and is treated as an opaque lane identifier at this layer.
+It is a 20-byte value.
 
-System-reserved subnetwork IDs:
+Post-activation, valid transaction subnetwork IDs are:
 
-* IDs of the form `x || 0x00..0x00` (one first byte `x`, followed by 19 zeros) are reserved for system usage by consensus.
-* This reserved set includes the currently hardcoded subnet IDs.
+* Native: `0x00 || 0x00..0x00` (one zero byte followed by 19 zero bytes).
+* Coinbase: `0x01 || 0x00..0x00` (one byte `0x01` followed by 19 zero bytes).
+* User lane: `namespace || 0x00..0x00`, where `namespace` is 4 bytes, the suffix is 16 zero bytes, and at least one byte in `namespace[1..=3]` is non-zero.
+
+Equivalently, the only valid 19-zero-suffix IDs are native and coinbase. Other IDs of the form `x || 0x00..0x00` are reserved for future system use and are invalid as transaction subnetwork IDs. Any shape other than the three valid forms listed above is invalid.
 
 Rationale for keying:
 
 * The committed SMT key is `lane_key(lane_id) = H_lane_key(lane_id)` (Section 6.1).
 * Hashing `lane_id` produces the fixed-width 256-bit key used by the active-lanes SMT.
 * This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs, including vProg-derived lane identifiers.
+
+#### 2.2 Block Lane and Gas Limits (Normative)
+
+For block admission, consensus applies the following lane limits to non-coinbase transactions:
+
+* A block may contain transactions from at most 50 distinct non-coinbase lanes.
+* For each non-coinbase lane, the sum of `tx.gas` over all transactions in that lane may not exceed `1_000_000_000`.
+* Native and reserved system lanes must use `tx.gas = 0`.
+
+The per-block lane cap bounds local SMT update work. At 10 BPS, the default limit of 50 non-coinbase lanes per block bounds worst-case user-lane updates to 500 per second. Its motivation is local compute and incremental state cost, not the asymptotic boundedness of the active set, which follows from the activity window `F` and inactivity purge.
+
+The selected-parent coinbase transaction is included in `AcceptedTxList(B)` and therefore participates in `SeqCommit(B)`, but it is not counted toward the block lane/gas admission limits above.
 
 ### 3. Data Model
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -502,13 +502,17 @@ Define:
 ```
 MergesetContextHash(B) =
     H_mergeset_context(
-        le_u64(B.header.timestamp)
+        le_u64(selected_parent(B).header.timestamp)
         || le_u64(B.header.daa_score)
-        || le_u64(B.header.blue_score)
+        || le_u64(B.blue_score)
     )
 ```
 
-`MergesetContextHash(B)` is committed both as part of `SeqStateRoot(B)` and inside each touched lane-tip update in `B`.
+`MergesetContextHash(B)` commits the selected-parent timestamp, accepting-block DAA score, and accepting-block blue score. It is committed both as part of `SeqStateRoot(B)` and inside each touched lane-tip update in `B`.
+
+Rationale: the accepting block timestamp is not yet available when building a deterministic block template, while the selected-parent timestamp is already fixed from the template's point of view. At Kaspa's high BPS rate, the timestamp difference from the selected parent is normally sub-second.
+
+Note: Kaspa timestamps are not strictly monotonic along the selected-parent chain. Applications that need monotonic time should enforce that rule at their own layer.
 
 ##### 6.5.2 Miner Payload Commitment (Mergeset Blocks)
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -192,8 +192,9 @@ Domain tags:
 | `H_lane_tip` | `"SeqCommitLaneTip"` |
 | `H_activity_leaf` | `"SeqCommitActivityLeaf"` |
 | `H_mergeset_context` | `"SeqCommitMergesetContext"` |
-| `H_miner_payload` | `"SeqCommitMinerPayload"` |
+| `H_payload_digest` | `"PayloadDigest"` |
 | `H_miner_payload_leaf` | `"SeqCommitMinerPayloadLeaf"` |
+| `H_activity_root` | `"SeqCommitActivityRoot"` |
 | `H_leaf` | `"SeqCommitActiveLeaf"` |
 | `H_node` | `"SeqCommitActiveNode"` |
 | `H_seq` | `"SeqCommitmentMerkleBranchHash"` |
@@ -337,9 +338,30 @@ This section defines how state is projected into the single header commitment. T
 At a high level:
 
 1. Commit the active lanes map into `ActiveLanesRoot(B)` via an SMT.
-2. Commit additional per-block context and miner payload data.
-3. Hash these together into `SeqStateRoot(B)`.
-4. Chain the state root through selected-parent ancestry into `SeqCommit(B)`.
+2. Combine `ActiveLanesRoot(B)` with the inactivity shortcut into `ActivityRoot(B)`.
+3. Commit additional per-block context and miner payload data into `PayloadAndContextDigest(B)`.
+4. Hash these together into `SeqStateRoot(B)`.
+5. Chain the state root through selected-parent ancestry into `SeqCommit(B)`.
+
+The resulting tree shape is:
+
+```text
+SeqCommit(B)
+└── H_seq
+    ├── parent_seq_commit = SeqCommit(selected_parent(B))
+    └── state_root
+        └── H_seq
+            ├── activity_root
+            │   └── H_activity_root
+            │       ├── inactivity_shortcut
+            │       └── lanes_root
+            │           └── SMT root over active lanes
+            │
+            └── payload_and_ctx_digest
+                └── H_seq
+                    ├── context_hash
+                    └── payload_root
+```
 
 #### 6.1 Keying
 
@@ -444,7 +466,7 @@ For each mergeset block `X`:
 For each mergeset block `X`, define:
 
 ```
-miner_payload_hash(X) = H_miner_payload(payload_bytes(X))
+miner_payload_hash(X) = H_payload_digest(payload_bytes(X))
 
 miner_payload_leaf(X) = H_miner_payload_leaf(
     X.hash
@@ -468,17 +490,30 @@ Merkle-root branching uses `H_seq` semantics (Section 4.2).
 Define:
 
 $$
+\mathrm{ActivityRoot}(B) =
+H_{\mathrm{activity\_root}}\big(
+\mathrm{InactivityShortcut}(B),
+\mathrm{ActiveLanesRoot}(B)
+\big).
+$$
+
+$$
+\mathrm{PayloadAndContextDigest}(B) =
+H_{\mathrm{seq}}\big(\mathrm{MergesetContextHash}(B), \mathrm{MinerPayloadRoot}(B)\big).
+$$
+
+$$
 \mathrm{SeqStateRoot}(B) =
 H_{\mathrm{seq}}\Big(
-\mathrm{ActiveLanesRoot}(B),
-H_{\mathrm{seq}}(\mathrm{MergesetContextHash}(B), \mathrm{MinerPayloadRoot}(B))
+\mathrm{ActivityRoot}(B),
+\mathrm{PayloadAndContextDigest}(B)
 \Big).
 $$
 
 Notes:
 
-* `ActiveLanesRoot(B)` is a direct child of `SeqStateRoot(B)`.
-* `MergesetContextHash(B)` and `MinerPayloadRoot(B)` are committed as the right child hash.
+* `ActiveLanesRoot(B)` is committed inside `ActivityRoot(B)` together with `InactivityShortcut(B)`.
+* `MergesetContextHash(B)` and `MinerPayloadRoot(B)` are committed inside `PayloadAndContextDigest(B)`.
 
 #### 6.7 Sequencing Commitment Recurrence (Normative)
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -331,6 +331,31 @@ ActiveLanes[lane_id].last_touch_blue_score + F <= B.blue_score
 
 Purged lanes are removed from `ActiveLanes`.
 
+#### 5.4 Inactivity Shortcut
+
+Let `F` be the same inactivity threshold used for lane purge.
+
+For each chain block `B`, define `InactivityShortcutBlock(B)` as follows:
+
+* If `B.blue_score < F + 1`, then `InactivityShortcutBlock(B) = genesis`.
+* Otherwise, let `target = B.blue_score - F - 1`. `InactivityShortcutBlock(B)` is the highest selected-parent-chain ancestor `A` of `B` such that `A.blue_score <= target`.
+
+The committed shortcut value is:
+
+```
+InactivityShortcut(B) =
+    ZERO_HASH                                  if InactivityShortcutBlock(B) is pre-activation
+    SeqCommit(InactivityShortcutBlock(B))      otherwise
+```
+
+Note: `SeqCommit(genesis)` is defined as `ZERO_HASH`.
+
+The shortcut points to the last selected-parent-chain block not covered by an exclusion proof at `B`: if a lane is absent from `ActiveLanesRoot(B)`, then by the purge rule it had no activity in the blocks after `InactivityShortcutBlock(B)` up to `B`. An inactivity proof can therefore hop from `B` to `InactivityShortcutBlock(B)` as its next proving target.
+
+This lets guests walk inactivity spans in `O(N/F)` hops instead of `O(N)`, without knowing `F`.
+
+The shortcut is committed next to `ActiveLanesRoot(B)` inside `ActivityRoot(B)` (Section 6.6).
+
 ### 6. Commitment Structure
 
 This section defines how state is projected into the single header commitment. The structure is intentionally layered: active-lanes state first, then per-block context/miner payloads, then selected-parent chaining.
@@ -513,6 +538,7 @@ $$
 Notes:
 
 * `ActiveLanesRoot(B)` is committed inside `ActivityRoot(B)` together with `InactivityShortcut(B)`.
+* `InactivityShortcut(B)` is defined in Section 5.4.
 * `MergesetContextHash(B)` and `MinerPayloadRoot(B)` are committed inside `PayloadAndContextDigest(B)`.
 
 #### 6.7 Sequencing Commitment Recurrence (Normative)

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -597,7 +597,7 @@ Notes:
 
 * `SeqCommit(B)` is chained through selected-parent ancestry (KIP-15 style recurrence).
 * `SeqStateRoot(B)` is not directly exposed in the header; it is committed by `SeqCommit(B)`.
-* `ActiveLanesRoot(B)` is not directly exposed in the header; it is committed by `SeqStateRoot(B)` and therefore by `SeqCommit(B)`.
+* `ActiveLanesRoot(B)` is not directly exposed in the header; it is committed through `ActivityRoot(B)`, `SeqStateRoot(B)`, and `SeqCommit(B)`.
 
 Post-activation, consensus sets:
 
@@ -680,7 +680,7 @@ For lane-local proving, the intended model is:
 
 The lane-diff witness size is proportional to lane activity between anchors, so this path is $O(a)$ rather than $O(\Delta B)$, where $a$ is app activity and $\Delta B$ is the number of chain blocks between anchors.
 
-Including $MergesetContextHash(B)$ in touched lane-tip updates is what makes accepting-block clock/context available on the lane-local path without forcing per-block global sequencing commitment processing.
+Including $MergesetContextHash(B)$ in touched lane-tip updates makes the selected-parent timestamp and accepting-block scores available on the lane-local path without forcing per-block global sequencing commitment processing.
 
 Miner payloads remain a block-level commitment ( $MinerPayloadRoot(B)$ ). Apps that rely on this data still track block-level witnesses across intermediate chain blocks.
 
@@ -703,7 +703,7 @@ This KIP is designed to remain compatible with a future full vProgs CD specifica
 Expected direction:
 
 * A vProg can be modeled as a lane under this KIP, just as subnets are modeled as lanes today.
-* In that setting, the outer commitment layer defined here (`ActiveLanesRoot(B)` inside `SeqCommit(B)`) already serves as the global live-vProg tree described in the vProgs DAG-root model (see [3]).
+* In that setting, the active-lanes SMT committed under `ActivityRoot(B)` inside `SeqCommit(B)` already serves as the global live-vProg tree described in the vProgs DAG-root model (see [3]).
 * A vProg lane tip would recurse from its previous anchor together with the newly introduced CD tips belonging to that vProg in the accepting block: concretely, the latest unproven account-state vertices written to by that vProg's transactions in the current mergeset.
 * Thus this KIP already prepares a substantial subset of the vProgs commitment design: the global outer partitioning and anchoring machinery can remain the same, while the lane-local update rule becomes CD-specific.
 * Subnet-based lanes defined by this KIP remain unchanged, so zk provers built over the current subnet-lane logic can continue to operate as-is after a CD upgrade.

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -688,9 +688,9 @@ Implementation note: storage/IO overhead can be reduced with known sparse-tree o
 
 ## References
 
-[1] KIP-15: Canonical Transaction Ordering and Sequencing Commitments.
-[2] Subnets sequencing commitments (original seed to this design): [https://research.kas.pa/t/subnets-sequencing-commitments/274](https://research.kas.pa/t/subnets-sequencing-commitments/274)
-[3] vProgs yellow paper: [https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf](https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf)
-[4] On the design of based zk-rollups over Kaspa's UTXO-based DAG consensus: [https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208](https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208)
-[5] L1/L2 canonical bridge entry/exit mechanism: [https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258](https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258)
-[6] Optimizing Sparse Merkle Trees: [https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751](https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751)
+[1] KIP-15: Canonical Transaction Ordering and Sequencing Commitments.  
+[2] Subnets sequencing commitments (original seed to this design): [https://research.kas.pa/t/subnets-sequencing-commitments/274](https://research.kas.pa/t/subnets-sequencing-commitments/274)  
+[3] vProgs yellow paper: [https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf](https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf)  
+[4] On the design of based zk-rollups over Kaspa's UTXO-based DAG consensus: [https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208](https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208)  
+[5] L1/L2 canonical bridge entry/exit mechanism: [https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258](https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258)  
+[6] Optimizing Sparse Merkle Trees: [https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751](https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751)  

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -2,9 +2,10 @@
 KIP: 21
 Layer: Consensus (hard fork), Chain-Block UTXO Validation
 Title: Partitioned Sequencing Commitment with O(activity) Proving
-Authors: Michael Sutton <msutton@cs.huji.ac.il>
-Status: Draft
+Authors: Michael Sutton <msutton@cs.huji.ac.il>, Maxim Biryukov (@biryukovmaxim), Hans Moog <hans.moog@kaspafoundation.org>
+Status: Implemented and activated in TN10
 Created: 2026-02-17
+Updated: 2026-05-28
 ```
 
 ## Abstract

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -659,13 +659,14 @@ Let:
 * $n = |AcceptedTxList(B)|$
 * $t = |TouchedLanes(B)|$
 * $p =$ number of purged lanes at $B$
+* $a = |ActiveLanes(B)|$
 
 Then:
 
 * Grouping activity by lane is $O(n)$.
-* Updating tips is $O(t)$.
-* Purge checks with the ordered index are $O(p \log |ActiveLanes|)$.
-* SMT update is $O((t+p)\log(2^{256})) = O((t+p)\cdot 256) = O(t+p)$ with a large constant factor (256 levels).
+* Updating lane tips is $O(t)$.
+* Purging $p$ inactive lanes removes $p$ entries from the active-lanes map; concrete discovery and indexing strategies are implementation-specific.
+* Active-lanes SMT updates and witnesses are capped by the 256-bit key depth, but under the collapsed single-leaf structure and hash-distributed lane keys, their effective size is governed by the branching depth of the active set, typically $O(\log a)$ per changed lane.
 
 #### 10.1 Global Order Reconstruction
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -38,15 +38,17 @@ Requirements:
 
 * Remain forward-compatible with future vProg-based lanes and richer lane-local update rules without replacing the core recurrence.
 
-## How to Read This KIP
+## Document Scope
 
-This document mixes consensus rules and proving/operations guidance. Use this reading path:
+This KIP is the consensus specification for KIP-21. It defines the post-activation state transition, committed values, header semantics, and pruning-point bootstrap requirements.
 
-* Consensus implementers: read *Terminology* through *Script Semantics*, then *Reorg-Safe Incremental Maintenance* and *Purge Index*, then *Relationship to Covenants++ Workstream* and *Backward Compatibility*.
-* Proving/witness implementers: read *Per-Lane Block Activity Digest (§4.2)*, *Update or Initialize Lane Tips (§5.2)*, and *Commitment Structure (§6)* (especially §6.3-§6.7), then *Complexity (§10)* and *Optional Persistent Witness Store (§11)*.
-* Quick orientation: read Abstract, Motivation, and *Mental Model (Reader Map)* first.
+Detailed implementation and proving guidance is split into companion documents:
 
-Where explicitly marked `(Normative)`, sections are intended to be consensus-critical. Sections marked `(Informative)` explain proving models and operational patterns that do not by themselves change consensus rules.
+* [Implementation Spec](kip-0021/impl-spec.md): rusty-kaspa implementation structure, versioned SMT state, pruning mechanics, and IBD import/export details.
+* [Seqcommit Accessor](kip-0021/seqcommit-accessor.md): `OpChainblockSeqCommit`, selected-parent point of view, depth thresholds, reorg handling, and headers-proof interaction.
+* [Proving Spec](kip-0021/proving-spec.md): lane proofs, inactivity proofs, guest algorithms, and witness formats.
+
+Sections explicitly marked `(Informative)` explain rationale or intended use and do not add consensus rules.
 
 ## Mental Model (Reader Map)
 
@@ -498,76 +500,13 @@ Notes:
 
 This KIP defines post-activation `accepted_id_merkle_root` semantics for `OpChainblockSeqCommit`.
 
-### 8. Reorg-Safe Incremental Maintenance
+### 8. Consensus State Maintenance
 
-Implementations maintain sequencing commitment state incrementally via reversible per-block diffs.
+Implementations must maintain enough sequencing-commitment state to deterministically compute `SeqCommit(B)` from `SeqCommit(parent(B))`, the active lane set at `parent(B)`, and block `B`'s accepted transaction and mergeset data.
 
-#### 8.1 Diff Content
+Implementations must also support selected-parent reorgs without changing the resulting committed state. The concrete diff, cache, index, and storage layout are implementation details and are not part of this KIP. The rusty-kaspa implementation strategy is described separately in [Implementation Spec](kip-0021/impl-spec.md).
 
-For each chain block `B`, define `SeqCommitDiff(B)` containing:
-
-1. lane mutations:
-
-   * `(lane, old_record_opt, new_record_opt)` for every inserted, updated, or removed lane.
-2. purge-index mutations:
-
-   * insert, update, and delete mutations in the score index for all touched/purged lanes.
-3. optional root transition cache:
-
-   * `old_root`, `new_root` for fast rollback/apply paths.
-
-#### 8.2 Reorg Operations
-
-Given a selected-parent reorg:
-
-1. walk down the old chain path and reverse `SeqCommitDiff`s in reverse order.
-2. walk up the new chain path and apply `SeqCommitDiff`s in forward order.
-
-This mirrors the existing UTXO-diff strategy and avoids full-state recomputation.
-
-### 9. Purge Index (Oldest-First / Heap-Oriented)
-
-Implementations provide oldest-score-first access for purge processing, equivalent to:
-
-1. `peek_oldest_score()`
-2. `pop_oldest_while(score <= purge_cutoff)`
-
-#### 9.1 On-Disk Ordered Index (RocksDB-Friendly)
-
-The canonical index is persisted in score order, enabling iterator-based popping without full scans.
-
-Recommended key layout:
-
-```
-LastTouchByScoreKey =
-    PREFIX_LAST_TOUCH_BY_SCORE
-    || be_u64(last_touch_blue_score)
-    || lane_key
-```
-
-Where:
-
-* `be_u64` is big-endian encoding.
-* `lane_key` disambiguates collisions for equal scores.
-
-Rationale:
-
-* RocksDB keys are lexicographically ordered.
-* With `be_u64(score)`, forward iteration yields oldest scores first.
-
-Equivalent encodings are allowed if they preserve deterministic oldest-first extraction semantics.
-
-#### 9.2 In-Memory Cache
-
-An implementation may maintain an in-memory min-heap over `(last_touch_blue_score, lane_key)` for hot-path purge checks.
-
-The heap is a cache/hint layer only; canonical correctness is defined by persisted state. Heap entries can become stale under updates/reorgs, so candidates popped from heap are validated against current persisted lane records before deletion.
-
-#### 9.3 Reorg and Diff Requirements
-
-All index mutations (insert/update/delete in `LastTouchByScore`) are part of `SeqCommitDiff` and are reversible under reorg.
-
-#### 9.4 IBD Bootstrap at Pruning Point (Normative)
+### 9. Pruning-Point Bootstrap Requirements (Normative)
 
 IBD from the pruning point (PP) must provide enough sequencing-commitment state for a new node to continue normal chain-block processing from PP onward.
 
@@ -579,16 +518,13 @@ At PP, an implementation must have (or reconstruct) the following minimum data:
 
 These are sufficient to verify `SeqStateRoot(PP)` and then verify `PP.accepted_id_merkle_root = SeqCommit(PP)` by the recurrence in Section 6.7.
 
-From that verified PP state, a node processes subsequent chain blocks by the same incremental rules in Sections 5-9 (touch/update/purge + diff maintenance).
+From that verified PP state, a node processes subsequent chain blocks by the same consensus state-transition rules in Sections 5-8.
 
-Operational note:
-
-* Implementations should retain the PP active set analogously to PP UTXO-set retention, and when PP advances, update it by advancing over sequencing-commitment diffs from the old PP to the new PP. This is required so IBD syncers can provide the minimum PP data listed above to syncing nodes.
-* Alternatively, an implementation may reconstruct the PP active set in linear time using the optional persistent witness-store structure (Section 11).
+Operational note: concrete retention, reconstruction, and wire-format choices are implementation details. They are described separately in [Implementation Spec](kip-0021/impl-spec.md).
 
 ## Informative: Proving and Witness Operations
 
-Sections 10 and 11 describe proving-oriented usage patterns and optional witness-serving infrastructure. They explain how to consume the committed structure, but do not add consensus rules beyond Sections 1-9.
+This section gives high-level proving intuition. Detailed guest algorithms, witness formats, and witness-serving strategies are outside the consensus rules and are described separately in [Proving Spec](kip-0021/proving-spec.md).
 
 ### 10. Complexity
 
@@ -607,7 +543,7 @@ Then:
 
 #### 10.1 Global Order Reconstruction
 
-If an upper layer needs global order reconstruction, it can reconstruct it by collecting the per-lane transaction sets and sorting by $`\mathrm{merge\_idx}`$ within the accepting block $B$. Verifying this reconstruction requires lane witnesses under the committed $SeqCommit(B)$ anchor and proving the relevant active-lanes SMT diff (or an equivalent witness relation) between anchors. This can be done by tracking (or recomputing) active-lanes SMT updates, or via the optional persistent witness-store approach in Section 11.
+If an upper layer needs global order reconstruction, it can reconstruct it by collecting the per-lane transaction sets and sorting by $`\mathrm{merge\_idx}`$ within the accepting block $B$. Verifying this reconstruction requires lane witnesses under the committed $SeqCommit(B)$ anchor and proving the relevant active-lanes SMT diff, or an equivalent witness relation, between anchors. Concrete witness strategies are outside this consensus document and are described separately in [Proving Spec](kip-0021/proving-spec.md).
 
 #### 10.2 Two-Anchor Lane Proof Model
 
@@ -634,26 +570,6 @@ For a lane that was purged and later re-appears, proving continuity typically ne
 Each non-inclusion checkpoint at blue score $s$ certifies inactivity for the preceding $F$-window ($[s-F, s]$) by the purge rule, so exclusion proofs do not need to be repeated inside that covered segment.
 
 This checkpoint pattern shows that no committed intermediate lane tip for $\ell$ exists between the old tip and the reactivation event.
-
-### 11. Optional Persistent Witness Store
-
-Clients (e.g., zk provers) may need inclusion and non-inclusion witnesses for a lane under older anchors (e.g., “5 hours ago”). Requiring each client to track the SMT live is heavy, and requiring nodes to rewind or replay diffs per witness request is also heavy. An optional auxiliary indexing layer can reconstruct witnesses directly from stored commitment structure.
-
-Implementation hints:
-
-* Maintain a unified, content-addressed commitment-node store:
-  `node_hash -> (left_child_hash, right_child_hash)`
-  covering both `H_seq` nodes (sequencing commitment and state roots) and SMT internal nodes (`H_node` under `ActiveLanesRoot`).
-
-* Witnesses can then be reconstructed directly from a header anchor `accepted_id_merkle_root = SeqCommit(B)` by descending the stored commitment DAG to the relevant subtree root (e.g., `ActiveLanesRoot(B)`; the descent from `SeqCommit(B)` to `ActiveLanesRoot(B)` follows a fixed path: right child to `SeqStateRoot(B)`, then left child to `ActiveLanesRoot(B)`, before the key-driven SMT path), and then following the SMT path for `lane_key(lane)` while collecting siblings.
-
-* Empty subtree hashes (`EMPTY_i`) are computable from the spec; the store only needs to retain non-empty nodes.
-
-Pruning and cleanup:
-
-* GC-like reference counting: maintain `refcount[node_hash]` alongside `node_hash -> (left,right)`.
-
-* Cleanup rule: on first insertion of `node_hash -> (left,right)` (i.e., if `node_hash` is not already present), increment `refcount[left]` and `refcount[right]`. Separately, treat every retained header anchor (`accepted_id_merkle_root`) as one additional reference to its root (increment on retention, decrement on prune), even if the root node already exists. When a header is pruned, decrement the root’s refcount; whenever a refcount hits zero, delete that node and recursively decrement its children. This layer is optional and does not replace reorg diffs for hot-path consensus maintenance.
 
 ## Future Compatibility with vProgs CD
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -260,14 +260,25 @@ Merkle-root semantics match the sequencing commitment Merkle-root behavior speci
 For a lane identifier `lane_id` in accepting block `B`, define a recursive update step:
 
 ```
-TipUpdateHash(parent_ref, lane_id, activity_digest, MergesetContextHash(B)) =
-    H_lane_tip(parent_ref || lane_id || activity_digest || MergesetContextHash(B))
+TipUpdateHash(parent_ref, lane_key, activity_digest, MergesetContextHash(B)) =
+    H_lane_tip(parent_ref || lane_key || activity_digest || MergesetContextHash(B))
+```
+
+Local lane-tip hash structure:
+
+```text
+lane_tip_hash
+└── H_lane_tip
+    ├── parent_ref
+    ├── lane_key = H_lane_key(lane_id)
+    ├── activity_digest = activity_digest_lane(B, lane_id)
+    └── context_hash = MergesetContextHash(B)
 ```
 
 where:
 
 * `parent_ref` is either the previous lane tip hash (if lane is already active) or a global anchor (Section 5.2).
-* `lane_id` is the lane identifier (Section 2.1).
+* `lane_key` is the sparse-Merkle key defined in Section 6.1.
 * `activity_digest` is `activity_digest_lane(B, lane_id)`.
 * `MergesetContextHash(B)` is defined in Section 6.5.1.
 
@@ -304,8 +315,9 @@ For each `lane_id in TouchedLanes(B)`:
 3. Else:
 
    * `parent_ref = SeqCommit(parent(B))`
-4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id, activity_digest_lane(B, lane_id), ctx_hash_B)`.
-5. Set:
+4. Compute `lk = lane_key(lane_id)`.
+5. Compute `tip_next = TipUpdateHash(parent_ref, lk, activity_digest_lane(B, lane_id), ctx_hash_B)`.
+6. Set:
 
    * `ActiveLanes[lane_id].lane_tip_hash = tip_next`
    * `ActiveLanes[lane_id].last_touch_blue_score = B.blue_score`
@@ -380,7 +392,10 @@ SeqCommit(B)
             │   └── H_activity_root
             │       ├── inactivity_shortcut
             │       └── lanes_root
-            │           └── SMT root over active lanes
+            │           └── SMT root over active lane entries 1..N
+            │               ├── ...
+            │               ├── entry_i = leaf_hash_i as defined in Section 6.2
+            │               └── ...
             │
             └── payload_and_ctx_digest
                 └── H_seq
@@ -404,8 +419,7 @@ Leaf payload for a lane identifier `lane_id`:
 
 ```
 leaf_payload(lane_id) =
-    lane_id
-    || lane_tip_hash
+    lane_tip_hash
     || le_u64(last_touch_blue_score)
 ```
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -105,7 +105,7 @@ This specification is written in two passes so readers can first follow the stat
 
 ### 1. Terminology
 
-* Lane (`lane`): the logical application lane tracked by this commitment scheme. (In this KIP, lanes are extracted from `tx.subnetwork_id`; future KIPs may define additional lane families such as vProg-based lanes.)
+* Lane (`lane`): an ordered subset of `AcceptedTxList(B)` identified by a lane ID. In this KIP, the lane ID is `tx.subnetwork_id`, so each lane contains exactly the accepted transactions with the same `subnetwork_id`, in their `AcceptedTxList(B)` order. Future KIPs may define additional lane families such as vProg-based lanes.
 * Lane Tip: the current recursive hash tip for one lane.
 * Active Lane: a lane whose lane tip is currently present in the commitment set.
 * Last-Touch Blue Score: blue score of the chain block that last updated the lane tip.

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -14,7 +14,7 @@ This KIP replaces the current per-chain-block linear sequencing commitment recur
 
 Instead of committing to all accepted transactions in every chain block as one global append-only stream, consensus maintains a commitment over the tips of active application lanes (defined in Section 1). Each active lane has its own recursive tip hash and last-touch blue score. Global order remains reconstructible via `merge_idx` (Section 10.1), but is no longer directly committed as one monolithic per-block list. The block header continues to expose a single `accepted_id_merkle_root` value (consumed by `OpChainblockSeqCommit`), but post-activation it commits to (i) the active-lanes sparse Merkle tree (SMT) root and (ii) per-block context and mergeset miner payloads, chained through selected-parent recursion.
 
-The primary goal is prover cost proportional to relevant lane activity (`O(activity)`) for zk proving systems that consume chain-block sequencing commitments as anchors, while preserving global anchoring and enabling bounded-memory eviction of inactive lanes. In addition, `SeqStateRoot(B)` commits block-level context needed by based zk systems (timestamp, DAA score, and blue score) and mergeset miner payloads, under the same chained commitment, and touched lane-tip updates include the same context hash.
+The primary goal is prover cost proportional to relevant lane activity (`O(activity)`) for zk proving systems that consume chain-block sequencing commitments as anchors, while preserving global anchoring and enabling bounded-memory eviction of inactive lanes. In addition, `SeqStateRoot(B)` commits block-level context needed by based zk systems (selected-parent timestamp, DAA score, and blue score) and mergeset miner payloads, under the same chained commitment, and touched lane-tip updates include the same context hash.
 
 ## Motivation
 
@@ -31,7 +31,7 @@ This scheme does not assume a fixed bound on historical lane-ID diversity. The c
 1. Keep a single 32-byte header commitment consumable by `OpChainblockSeqCommit`.
 2. Make per-lane proving scale with that lane’s own activity.
 3. Enable bounded-memory behavior via inactivity purge keyed by blue score.
-4. Define an incremental consensus state that supports reorg rollbacks with diff application/reversal.
+4. Define a deterministic selected-parent state transition whose committed result is stable under DAG reorg processing.
 5. Commit additional block context and mergeset miner payloads needed by based zk systems under the same chained commitment.
 6. Keep pre-activation behavior unchanged.
 
@@ -60,8 +60,8 @@ The shortest way to think about the construction is:
 3. group transactions by lane;
 4. compute one `activity_digest_lane(B, lane_id)` per touched lane, with `merge_idx` committed per tx;
 5. update each touched lane tip recursively (existing lane uses previous lane tip; re-appearing lane after purge anchors to `SeqCommit(parent(B))`);
-6. store updated lane-tip records in the active-lanes SMT to get `ActiveLanesRoot(B)`;
-7. compute block context hash (`timestamp`, `daa_score`, `blue_score`) and miner-payload root;
+6. commit updated active-lane entries in the active-lanes SMT to get `ActiveLanesRoot(B)`;
+7. compute block context hash (selected-parent `timestamp`, `daa_score`, `blue_score`) and miner-payload root;
 8. combine these into `SeqStateRoot(B)`;
 9. chain through selected parent to get `SeqCommit(B)`;
 10. publish `SeqCommit(B)` in `accepted_id_merkle_root`.

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -57,7 +57,7 @@ The shortest way to think about the construction is:
 1. start from the accepted transaction sequence `AcceptedTxList(B)` (selected-parent coinbase first);
 2. extract lane IDs (`lane_id`) from transactions;
 3. group transactions by lane;
-4. compute one `activity_digest_lane(B)` per touched lane, with `merge_idx` committed per tx;
+4. compute one `activity_digest_lane(B, lane_id)` per touched lane, with `merge_idx` committed per tx;
 5. update each touched lane tip recursively (existing lane uses previous lane tip; re-appearing lane after purge anchors to `SeqCommit(parent(B))`);
 6. store updated lane-tip records in the active-lanes SMT to get `ActiveLanesRoot(B)`;
 7. compute block context hash (`timestamp`, `daa_score`, `blue_score`) and miner-payload root;
@@ -77,7 +77,7 @@ Selected-parent SeqCommit chain (global, deep):
        v               v               v               v                               v
    ActiveLanes0    ActiveLanes1    ActiveLanes2    ActiveLanes3                   ActiveLanesN
 
-For one target lane (lane = L), proofs only touch the two anchors and lane-local transition:
+For one target lane `L`, proofs only touch the two anchors and lane-local transition:
 
   anchor start                                                      anchor end
       |                                                                 |
@@ -139,8 +139,8 @@ System-reserved subnetwork IDs:
 
 Rationale for keying:
 
-* The committed SMT key is `lane_key(lane) = H_lane_key(lane_id(lane))` (Section 6.1).
-* Because key width is normalized by `H_lane_key`, zero-padding lane IDs is unnecessary.
+* The committed SMT key is `lane_key(lane_id) = H_lane_key(lane_id)` (Section 6.1).
+* Hashing `lane_id` produces the fixed-width 256-bit key used by the active-lanes SMT.
 * This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs, including vProg-derived lane identifiers.
 
 ### 3. Data Model
@@ -149,7 +149,7 @@ Consensus maintains a per-block state `S(B)` derived from `S(parent(B))`:
 
 ```
 S(B) = {
-  ActiveLanes: map lane -> (lane_tip_hash, last_touch_blue_score)
+  ActiveLanes: map lane_id -> (lane_tip_hash, last_touch_blue_score)
 }
 ```
 
@@ -206,7 +206,7 @@ tx_digest(tx) = seq_commit_tx_digest(tx.id, tx.version)
 
 #### 4.2 Per-Lane Block Activity Digest
 
-Intuition: This section defines what “happened for lane `lane` in block `B`” as a single hash. We do this by
+Intuition: This section defines what happened for the lane identified by `lane_id` in block `B` as a single hash. We do this by
 committing to (i) the transaction digest and (ii) a block-local index (`merge_idx`) which lets upper layers
 reconstruct global order when needed.
 
@@ -220,7 +220,7 @@ Definition:
 merge_idx(tx) = position of tx in AcceptedTxList(B)   // 0..len-1
 ```
 
-For a lane `lane`, define `LaneTxList(B, lane)` to be the list of all accepted transactions in `B` whose lane extraction yields `lane`, in the same relative order they appear in `AcceptedTxList(B)`.
+For a lane identifier `lane_id`, define `LaneTxList(B, lane_id)` to be the list of all accepted transactions in `B` whose lane ID is `lane_id`, in the same relative order they appear in `AcceptedTxList(B)`.
 
 Define the per-lane activity leaf for each transaction:
 
@@ -231,7 +231,7 @@ activity_leaf(tx) = H_activity_leaf(tx_digest(tx) || le_u32(merge_idx(tx)))
 Define the per-lane activity digest as a Merkle root over the leaf list:
 
 ```
-activity_digest_lane(B) = MerkleRoot([activity_leaf(tx) for tx in LaneTxList(B, lane)])
+activity_digest_lane(B, lane_id) = MerkleRoot([activity_leaf(tx) for tx in LaneTxList(B, lane_id)])
 ```
 
 Merkle-root semantics match the sequencing commitment Merkle-root behavior specified by this KIP:
@@ -242,18 +242,18 @@ Merkle-root semantics match the sequencing commitment Merkle-root behavior speci
 
 #### 4.3 Tip Update Hash
 
-For lane `lane` in accepting block `B`, define a recursive update step:
+For a lane identifier `lane_id` in accepting block `B`, define a recursive update step:
 
 ```
-TipUpdateHash(parent_ref, lane_id(lane), activity_digest, MergesetContextHash(B)) =
-    H_lane_tip(parent_ref || lane_id(lane) || activity_digest || MergesetContextHash(B))
+TipUpdateHash(parent_ref, lane_id, activity_digest, MergesetContextHash(B)) =
+    H_lane_tip(parent_ref || lane_id || activity_digest || MergesetContextHash(B))
 ```
 
 where:
 
 * `parent_ref` is either the previous lane tip hash (if lane is already active) or a global anchor (Section 5.2).
-* `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
-* `activity_digest` is `activity_digest_lane(B)`.
+* `lane_id` is the lane identifier (Section 2.1).
+* `activity_digest` is `activity_digest_lane(B, lane_id)`.
 * `MergesetContextHash(B)` is defined in Section 6.5.1.
 
 ### 5. Per-Block State Transition
@@ -267,10 +267,10 @@ Let `S_prev = S(parent(B))`.
 Define the set of touched lanes in block `B`:
 
 ```
-Touched(B) = { lane | exists tx in AcceptedTxList(B) with lane(tx) = lane }
+TouchedLanes(B) = { lane_id | exists tx in AcceptedTxList(B) with lane_id(tx) = lane_id }
 ```
 
-For each `lane in Touched(B)`, compute `activity_digest_lane(B)` as in Section 4.2.
+For each `lane_id in TouchedLanes(B)`, compute `activity_digest_lane(B, lane_id)` as in Section 4.2.
 
 #### 5.2 Update or Initialize Lane Tips
 
@@ -280,20 +280,20 @@ Before iterating touched lanes, compute:
 ctx_hash_B = MergesetContextHash(B)
 ```
 
-For each `lane in Touched(B)`:
+For each `lane_id in TouchedLanes(B)`:
 
-1. Compute `activity_digest_lane(B)`.
-2. If `lane` exists in `S_prev.ActiveLanes`:
+1. Compute `activity_digest_lane(B, lane_id)`.
+2. If `lane_id` exists in `S_prev.ActiveLanes`:
 
-   * `parent_ref = S_prev.ActiveLanes[lane].lane_tip_hash`
+   * `parent_ref = S_prev.ActiveLanes[lane_id].lane_tip_hash`
 3. Else:
 
    * `parent_ref = SeqCommit(parent(B))`
-4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id(lane), activity_digest_lane(B), ctx_hash_B)`.
+4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id, activity_digest_lane(B, lane_id), ctx_hash_B)`.
 5. Set:
 
-   * `ActiveLanes[lane].lane_tip_hash = tip_next`
-   * `ActiveLanes[lane].last_touch_blue_score = B.blue_score`
+   * `ActiveLanes[lane_id].lane_tip_hash = tip_next`
+   * `ActiveLanes[lane_id].last_touch_blue_score = B.blue_score`
 
 This gives:
 
@@ -308,10 +308,10 @@ To allow bounded memory, lanes are purged after a fixed inactivity threshold.
 
 Let `F` be a protocol parameter measured in blue score units.
 
-A lane `lane` is purged at block `B` if:
+A lane identified by `lane_id` is purged at block `B` if:
 
 ```
-ActiveLanes[lane].last_touch_blue_score + F <= B.blue_score
+ActiveLanes[lane_id].last_touch_blue_score + F <= B.blue_score
 ```
 
 Purged lanes are removed from `ActiveLanes`.
@@ -329,34 +329,34 @@ At a high level:
 
 #### 6.1 Keying
 
-Define the sparse-Merkle key for lane `lane`:
+Define the sparse-Merkle key for a lane identifier `lane_id`:
 
 ```
-lane_key(lane) = H_lane_key(lane_id(lane))    // 32-byte key
+lane_key(lane_id) = H_lane_key(lane_id)    // 32-byte key
 ```
 
-where `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+where `lane_id` is the lane identifier (Section 2.1).
 
 #### 6.2 Leaf Value
 
-Leaf payload for lane `lane`:
+Leaf payload for a lane identifier `lane_id`:
 
 ```
-leaf_payload_lane =
-    lane_id(lane)
+leaf_payload(lane_id) =
+    lane_id
     || lane_tip_hash
     || le_u64(last_touch_blue_score)
 ```
 
 where:
 
-* `lane_id(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
-* `lane_tip_hash` and `last_touch_blue_score` are taken from `ActiveLanes[lane]`.
+* `lane_id` is the lane identifier (Section 2.1).
+* `lane_tip_hash` and `last_touch_blue_score` are taken from `ActiveLanes[lane_id]`.
 
 Leaf hash:
 
 ```
-leaf_hash_lane = H_leaf(leaf_payload_lane)
+leaf_hash(lane_id) = H_leaf(leaf_payload(lane_id))
 ```
 
 #### 6.3 Root
@@ -364,7 +364,7 @@ leaf_hash_lane = H_leaf(leaf_payload_lane)
 The sparse Merkle root over all active leaves is the active lanes root:
 
 ```
-ActiveLanesRoot(B) = SMT_Root({ lane_key(lane) -> leaf_hash_lane | lane in ActiveLanes })
+ActiveLanesRoot(B) = SMT_Root({ lane_key(lane_id) -> leaf_hash(lane_id) | lane_id in ActiveLanes })
 ```
 
 Consensus sets:
@@ -378,7 +378,7 @@ B.header.accepted_id_merkle_root = SeqCommit(B)
 This KIP defines `SMT_Root` as a fixed-depth (256) sparse Merkle tree:
 
 1. Keys are 256-bit strings (`lane_key`), interpreted MSB-first as a path.
-2. Leaves exist at depth 256 and hold `leaf_hash_lane` (32 bytes) for active lanes; all other leaves are empty.
+2. Leaves exist at depth 256 and hold `leaf_hash(lane_id)` (32 bytes) for active lanes; all other leaves are empty.
 3. Empty leaf hash is `EMPTY_0 = ZERO_HASH`.
 4. Internal empty node hash at height `i+1` is:
 
@@ -526,7 +526,7 @@ This section gives high-level proving intuition. Detailed guest algorithms, witn
 Let:
 
 * $n = |AcceptedTxList(B)|$
-* $t = |Touched(B)|$
+* $t = |TouchedLanes(B)|$
 * $p =$ number of purged lanes at $B$
 
 Then:

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -36,7 +36,7 @@ This scheme does not assume a fixed bound on the number of active lanes. In the 
 
 Requirements:
 
-* Remain forward-compatible with a future account-level extraction granularity without replacing the core recurrence.
+* Remain forward-compatible with future vProg-based lanes and richer lane-local update rules without replacing the core recurrence.
 
 ## How to Read This KIP
 
@@ -103,7 +103,7 @@ This specification is written in two passes so readers can first follow the stat
 
 ### 1. Terminology
 
-* Lane (`lane`): the logical application lane tracked by this commitment scheme. (In this KIP, lanes are extracted from `tx.subnetwork_id`; future KIPs may define finer-grained lane extraction such as account-level lanes.)
+* Lane (`lane`): the logical application lane tracked by this commitment scheme. (In this KIP, lanes are extracted from `tx.subnetwork_id`; future KIPs may define additional lane families such as vProg-based lanes.)
 * Lane Tip: the current recursive hash tip for one lane.
 * Active Lane: a lane whose lane tip is currently present in the commitment set.
 * Last-Touch Blue Score: blue score of the chain block that last updated the lane tip.
@@ -122,7 +122,7 @@ For this KIP, lanes are extracted from accepted transactions as follows:
 * This includes the selected-parent coinbase transaction, which uses the dedicated coinbase subnetwork ID.
 * This KIP does not merge built-in/native IDs into a single SYS lane; native, coinbase, and registry subnet IDs are mapped as distinct lanes.
 
-This keeps the mechanism consensus-native and deterministic with current transaction structure. Future KIPs may define additional lane extraction modes (e.g., account-level lanes), while reusing the same commitment machinery.
+This keeps the mechanism consensus-native and deterministic with current transaction structure. Future KIPs may define additional lane families and lane-local update rules (e.g., vProg-based CD commitments), while reusing the same outer commitment machinery.
 
 #### 2.1 Canonical Lane ID Encoding (Normative)
 
@@ -144,7 +144,7 @@ Rationale for keying:
 
 * The committed SMT key is `lane_key(lane) = H_lane_key(lane_id_bytes(lane))` (Section 6.1).
 * Because key width is normalized by `H_lane_key`, zero-padding lane IDs is unnecessary.
-* This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs.
+* This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs, including vProg-derived lane identifiers.
 
 ### 3. Data Model
 
@@ -661,9 +661,12 @@ This KIP is designed to remain compatible with a future full vProgs CD specifica
 
 Expected direction:
 
-* Account-level lanes may use a richer diff-style update rule (CD-like, with transaction vertices and account vertices).
+* A vProg can be modeled as a lane under this KIP, just as subnets are modeled as lanes today.
+* In that setting, the outer commitment layer defined here (`ActiveLanesRoot(B)` inside `SeqCommit(B)`) already serves as the global live-vProg tree described in the vProgs DAG-root model (see [3]).
+* A vProg lane tip would recurse from its previous anchor together with the newly introduced CD tips belonging to that vProg in the accepting block: concretely, the latest unproven account-state vertices written to by that vProg's transactions in the current mergeset.
+* Thus this KIP already prepares a substantial subset of the vProgs commitment design: the global outer partitioning and anchoring machinery can remain the same, while the lane-local update rule becomes CD-specific.
 * Subnet-based lanes defined by this KIP remain unchanged, so zk provers built over the current subnet-lane logic can continue to operate as-is after a CD upgrade.
-* A full CD model may allow re-anchoring to a previously proven lane/account state, instead of always falling back to `SeqCommit(parent(B))` when state is absent from the active set.
+* A full CD model may also allow re-anchoring to a previously proven vProg/account commitment, instead of always falling back to `SeqCommit(parent(B))` when state is absent from the active set.
 
 This section is informative only; it does not change the normative subnet-lane rules specified above.
 

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -1,0 +1,667 @@
+```
+KIP: 21
+Layer: Consensus (hard fork), Chain-Block UTXO Validation
+Title: Partitioned Sequencing Commitment with O(activity) Proving
+Authors: Michael Sutton <msutton@cs.huji.ac.il>
+Status: Draft
+Created: 2026-02-17
+```
+
+## Abstract
+
+This KIP replaces the current per-chain-block linear sequencing commitment recurrence with a partitioned sequencing commitment scheme.
+
+Instead of committing to all accepted transactions in every chain block as one global append-only stream, consensus maintains a commitment over the tips of active application lanes. Each active lane has its own recursive tip hash and last-touch blue score. Global order remains reconstructible via `merge_idx` (Section 10.1), but is no longer directly committed as one monolithic per-block list. The block header continues to expose a single `accepted_id_merkle_root` value (consumed by `OpChainblockSeqCommit`), but post-activation it commits to (i) the active-lanes sparse Merkle tree (SMT) root and (ii) per-block context and mergeset miner payloads, chained through selected-parent recursion.
+
+The primary goal is prover cost proportional to relevant lane activity (`O(activity)`) for zk proving systems that consume chain-block sequencing commitments as anchors, while preserving global anchoring and enabling bounded-memory eviction of inactive lanes. In addition, `SeqStateRoot(B)` commits block-level context needed by based zk systems (timestamp, DAA score, and blue score) and mergeset miner payloads, under the same chained commitment, and touched lane-tip updates include the same context hash.
+
+## Motivation
+
+ZK provers for application-level state machines, based computation lanes, and other “app-local” systems often need to prove statements that are naturally scoped to a single application lane.
+
+Under the current linear per-block recurrence, proving correctness for lane-specific execution can require processing or committing to global activity in every block, even if a prover only cares about one lane. This creates prover cost proportional to global throughput.
+
+By committing to lane tips (and lane-local block activity digests) rather than to the entire global stream, this KIP makes lane proofs proportional to lane activity, enabling `O(activity)`-style proving.
+
+This scheme does not assume a fixed bound on the number of active lanes. In the worst case, each transaction may belong to a distinct lane. However, the committed active set is bounded by the number of lanes touched within the activity window `F`, and `F` is strictly less than pruning depth. Therefore, node storage is not increased asymptotically: the “hot” commitment set scales with recent activity, not with historical diversity of lane IDs.
+
+## Goals
+
+1. Keep a single 32-byte header commitment consumable by `OpChainblockSeqCommit`.
+2. Make per-lane proving scale with that lane’s own activity.
+3. Enable bounded-memory behavior via inactivity purge keyed by blue score.
+4. Define an incremental consensus state that supports reorg rollbacks with diff application/reversal.
+5. Commit additional block context and mergeset miner payloads needed by based zk systems under the same chained commitment.
+6. Keep pre-activation behavior unchanged.
+
+Requirements:
+
+* Remain forward-compatible with a future account-level extraction granularity without replacing the core recurrence.
+
+## How to Read This KIP
+
+This document mixes consensus rules and proving/operations guidance. Use this reading path:
+
+* Consensus implementers: read *Terminology* through *Script Semantics*, then *Reorg-Safe Incremental Maintenance* and *Purge Index*, then *Relationship to Covenants++ Workstream* and *Backward Compatibility*.
+* Proving/witness implementers: read *Per-Lane Block Activity Digest (§4.2)*, *Update or Initialize Lane Tips (§5.2)*, and *Commitment Structure (§6)* (especially §6.3-§6.7), then *Complexity (§10)* and *Optional Persistent Witness Store (§11)*.
+* Quick orientation: read Abstract, Motivation, and *Mental Model (Reader Map)* first.
+
+Where explicitly marked `(Normative)`, sections are intended to be consensus-critical. Sections marked `(Informative)` explain proving models and operational patterns that do not by themselves change consensus rules.
+
+## Mental Model (Reader Map)
+
+The shortest way to think about the construction is:
+
+1. start from the accepted transaction sequence `AcceptedTxList(B)` (selected-parent coinbase first);
+2. extract lane IDs (`lane_id_bytes`) from transactions;
+3. group transactions by lane;
+4. compute one `activity_digest_lane(B)` per touched lane, with `merge_idx` committed per tx;
+5. update each touched lane tip recursively (existing lane uses previous lane tip; re-appearing lane after purge anchors to `SeqCommit(parent(B))`);
+6. store updated lane-tip records in the active-lanes SMT to get `ActiveLanesRoot(B)`;
+7. compute block context hash (`timestamp`, `daa_score`, `blue_score`) and miner-payload root;
+8. combine these into `SeqStateRoot(B)`;
+9. chain through selected parent to get `SeqCommit(B)`;
+10. publish `SeqCommit(B)` in `accepted_id_merkle_root`.
+
+This yields one header commitment for consensus, while preserving lane-local witnesses for `O(activity)` proving between anchors.
+
+## Specification
+
+This specification is written in two passes so readers can first follow the state transition mechanics and then see exactly how that state is committed in the header:
+
+1. **Active lane management:** how lane tips are updated and purged as a function of accepted transactions.
+2. **What the header commits to:** how we commit those tips (and additional context) into `SeqCommit(B)`.
+
+### 1. Terminology
+
+* Lane (`lane`): the logical application lane tracked by this commitment scheme. (In this KIP, lanes are extracted from `tx.subnetwork_id`; future KIPs may define finer-grained lane extraction such as account-level lanes.)
+* Lane Tip: the current recursive hash tip for one lane.
+* Active Lane: a lane whose lane tip is currently present in the commitment set.
+* Last-Touch Blue Score: blue score of the chain block that last updated the lane tip.
+* Active Lanes Root (`ActiveLanesRoot(B)`): the sparse-Merkle root committing to the active lane tips at chain block `B` (Section 6.3).
+* Sequencing State Root (`SeqStateRoot(B)`): commits to the active-lanes root and additional context/miner-payload data at chain block `B` (Section 6.6). This is distinct from the UTXO commitment (`utxo_commitment`).
+* Sequencing Commitment (`SeqCommit(B)`): the value stored in `B.header.accepted_id_merkle_root` post-activation (Section 6.7).
+* Mergeset Index (`merge_idx`): the 0-based index of a transaction within `AcceptedTxList(B)` (Section 4.2).
+* Accepting Block (`B`): the chain block whose `SeqCommit(B)` is being computed.
+* Mergeset Miner Payload: raw coinbase payload bytes from mergeset blocks, committed by this KIP (Section 6.5.2).
+
+### 2. Lane Extraction
+
+For this KIP, lanes are extracted from accepted transactions as follows:
+
+* For each accepted transaction `tx`, the lane selector is `tx.subnetwork_id`.
+* This includes the selected-parent coinbase transaction, which uses the dedicated coinbase subnetwork ID.
+* This KIP does not merge built-in/native IDs into a single SYS lane; native, coinbase, and registry subnet IDs are mapped as distinct lanes.
+
+This keeps the mechanism consensus-native and deterministic with current transaction structure. Future KIPs may define additional lane extraction modes (e.g., account-level lanes), while reusing the same commitment machinery.
+
+#### 2.1 Canonical Lane ID Encoding (Normative)
+
+This KIP defines a canonical lane identifier byte string `lane_id_bytes`.
+
+Current encoding (subnetwork lanes):
+
+* Let `subnetwork_id` be the canonical 20-byte `tx.subnetwork_id`.
+* Define `lane_id_bytes = subnetwork_id` (20 bytes, no padding).
+
+System-reserved subnetwork IDs:
+
+* IDs of the form `x || 0x00..0x00` (one first byte `x`, followed by 19 zeros) are reserved for system usage by consensus.
+* This reserved set includes the currently hardcoded subnet IDs.
+
+Consensus nodes treat `lane_id_bytes` as opaque identifiers at this layer.
+
+Rationale for keying:
+
+* The committed SMT key is `lane_key(lane) = H_lane_key(lane_id_bytes(lane))` (Section 6.1).
+* Because key width is normalized by `H_lane_key`, zero-padding lane IDs is unnecessary.
+* This also keeps lane-ID encoding decoupled from SMT keyspace layout and leaves room for future composite lane IDs.
+
+### 3. Data Model
+
+Consensus maintains a per-block state `S(B)` derived from `S(parent(B))`:
+
+```
+S(B) = {
+  ActiveLanes: map lane -> (lane_tip_hash, last_touch_blue_score)
+}
+```
+
+Only lanes that are currently “active” (not purged) appear in `ActiveLanes`.
+
+### 4. Hashing and Encodings
+
+This section defines byte-level hashing and encoding rules used by per-lane activity and tip updates.
+
+#### 4.0 Encoding and Hash Domain Definitions
+
+All hash functions in this KIP are BLAKE3 with explicit domain separation tags.
+
+Keyed-hash notation:
+
+```
+H_tag(m) = BLAKE3(key = tag, input = m)
+```
+
+Domain tags:
+
+| Symbol | Domain tag |
+| --- | --- |
+| `H_lane_key` | `"SeqCommitLaneKey"` |
+| `H_lane_tip` | `"SeqCommitLaneTip"` |
+| `H_activity_leaf` | `"SeqCommitActivityLeaf"` |
+| `H_mergeset_context` | `"SeqCommitMergesetContext"` |
+| `H_miner_payload` | `"SeqCommitMinerPayload"` |
+| `H_miner_payload_leaf` | `"SeqCommitMinerPayloadLeaf"` |
+| `H_leaf` | `"SeqCommitActiveLeaf"` |
+| `H_node` | `"SeqCommitActiveNode"` |
+| `H_seq` | `"SeqCommitmentMerkleBranchHash"` |
+
+`H_seq` is the same branch hasher domain separator used by the currently deployed post-covenants sequencing commitment path (`SeqCommitmentMerkleBranchHash`). This KIP formalizes that behavior and extends it with lane/state commitments.
+
+For convenience, `H_seq(x, y)` means `H_seq(x || y)` where `x` and `y` are 32-byte values.
+
+#### 4.1 Primitive Encodings and Transaction Digest
+
+Primitive encodings:
+
+* `le_u{32,64}(x)`: fixed-width little-endian encoding.
+* `var_bytes(b)`: `le_u64(len(b)) || b`.
+* `blue_work_bytes(work)`: big-endian bytes of `work` with leading zero bytes removed (empty byte-string for `work = 0`).
+* `blue_work_encoding(work)`: `var_bytes(blue_work_bytes(work))`.
+
+`blue_work_encoding` matches the consensus hashing semantics used by `rusty-kaspa` header hashing (`write_blue_work`).
+
+Transaction digest:
+
+```
+tx_digest(tx) = seq_commit_tx_digest(tx.id, tx.version)
+```
+
+#### 4.2 Per-Lane Block Activity Digest
+
+Intuition: This section defines what “happened for lane `lane` in block `B`” as a single hash. We do this by
+committing to (i) the transaction digest and (ii) a block-local index (`merge_idx`) which lets upper layers
+reconstruct global order when needed.
+
+Let `AcceptedTxList(B)` be the ordered list of all accepted transactions in chain block `B`, in canonical acceptance order. The sequence starts with the selected-parent coinbase transaction, followed by accepted non-coinbase transactions in consensus order.
+
+For each `tx` in `AcceptedTxList(B)`, define its mergeset index:
+
+Definition:
+
+```
+merge_idx(tx) = position of tx in AcceptedTxList(B)   // 0..len-1
+```
+
+For a lane `lane`, define `LaneTxList(B, lane)` to be the list of all accepted transactions in `B` whose lane extraction yields `lane`, in the same relative order they appear in `AcceptedTxList(B)`.
+
+Define the per-lane activity leaf for each transaction:
+
+```
+activity_leaf(tx) = H_activity_leaf(tx_digest(tx) || le_u32(merge_idx(tx)))
+```
+
+Define the per-lane activity digest as a Merkle root over the leaf list:
+
+```
+activity_digest_lane(B) = MerkleRoot([activity_leaf(tx) for tx in LaneTxList(B, lane)])
+```
+
+Merkle-root semantics match the sequencing commitment Merkle-root behavior specified by this KIP:
+
+* Empty list root is `ZERO_HASH` (32 zero bytes).
+* Single entry root is `H_seq(entry, ZERO_HASH)` (not the entry itself).
+* Internal nodes are `H_seq(left, right)`.
+
+#### 4.3 Tip Update Hash
+
+For lane `lane` in accepting block `B`, define a recursive update step:
+
+```
+TipUpdateHash(parent_ref, lane_id_bytes(lane), activity_digest, MergesetContextHash(B)) =
+    H_lane_tip(parent_ref || lane_id_bytes(lane) || activity_digest || MergesetContextHash(B))
+```
+
+where:
+
+* `parent_ref` is either the previous lane tip hash (if lane is already active) or a global anchor (Section 5.2).
+* `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+* `activity_digest` is `activity_digest_lane(B)`.
+* `MergesetContextHash(B)` is defined in Section 6.5.1.
+
+### 5. Per-Block State Transition
+
+This section defines the deterministic state transition from `S(parent(B))` to `S(B)`. Conceptually, only two things can change at block `B`: touched lanes are updated, and stale lanes are purged.
+
+Let `S_prev = S(parent(B))`.
+
+#### 5.1 Group Activity by Lane
+
+Define the set of touched lanes in block `B`:
+
+```
+Touched(B) = { lane | exists tx in AcceptedTxList(B) with lane(tx) = lane }
+```
+
+For each `lane in Touched(B)`, compute `activity_digest_lane(B)` as in Section 4.2.
+
+#### 5.2 Update or Initialize Lane Tips
+
+Before iterating touched lanes, compute:
+
+```
+ctx_hash_B = MergesetContextHash(B)
+```
+
+For each `lane in Touched(B)`:
+
+1. Compute `activity_digest_lane(B)`.
+2. If `lane` exists in `S_prev.ActiveLanes`:
+
+   * `parent_ref = S_prev.ActiveLanes[lane].lane_tip_hash`
+3. Else:
+
+   * `parent_ref = SeqCommit(parent(B))`
+4. Compute `tip_next = TipUpdateHash(parent_ref, lane_id_bytes(lane), activity_digest_lane(B), ctx_hash_B)`.
+5. Set:
+
+   * `ActiveLanes[lane].lane_tip_hash = tip_next`
+   * `ActiveLanes[lane].last_touch_blue_score = B.blue_score`
+
+This gives:
+
+* continuity for already-active lanes,
+* and global anchoring for lanes re-appearing after inactivity purge.
+
+Rationale: a lane that has been purged has no committed tip in the active-set root. Anchoring a re-appearing lane to `SeqCommit(parent(B))` re-attaches it to a globally committed point without requiring retention of inactive lane tips. Reactivation proving with non-inclusion checkpoints is described in Section 10.3.
+
+#### 5.3 Inactivity Purge
+
+To allow bounded memory, lanes are purged after a fixed inactivity threshold.
+
+Let `F` be a protocol parameter measured in blue score units.
+
+A lane `lane` is purged at block `B` if:
+
+```
+ActiveLanes[lane].last_touch_blue_score + F <= B.blue_score
+```
+
+Purged lanes are removed from `ActiveLanes`.
+
+### 6. Commitment Structure
+
+This section defines how state is projected into the single header commitment. The structure is intentionally layered: active-lanes state first, then per-block context/miner payloads, then selected-parent chaining.
+
+At a high level:
+
+1. Commit the active lanes map into `ActiveLanesRoot(B)` via an SMT.
+2. Commit additional per-block context and miner payload data.
+3. Hash these together into `SeqStateRoot(B)`.
+4. Chain the state root through selected-parent ancestry into `SeqCommit(B)`.
+
+#### 6.1 Keying
+
+Define the sparse-Merkle key for lane `lane`:
+
+```
+lane_key(lane) = H_lane_key(lane_id_bytes(lane))    // 32-byte key
+```
+
+where `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+
+#### 6.2 Leaf Value
+
+Leaf payload for lane `lane`:
+
+```
+leaf_payload_lane =
+    lane_id_bytes(lane)
+    || lane_tip_hash
+    || le_u64(last_touch_blue_score)
+```
+
+where:
+
+* `lane_id_bytes(lane)` is the canonical lane ID encoding for lane `lane` (Section 2.1).
+* `lane_tip_hash` and `last_touch_blue_score` are taken from `ActiveLanes[lane]`.
+
+Leaf hash:
+
+```
+leaf_hash_lane = H_leaf(leaf_payload_lane)
+```
+
+#### 6.3 Root
+
+The sparse Merkle root over all active leaves is the active lanes root:
+
+```
+ActiveLanesRoot(B) = SMT_Root({ lane_key(lane) -> leaf_hash_lane | lane in ActiveLanes })
+```
+
+Consensus sets:
+
+```
+B.header.accepted_id_merkle_root = SeqCommit(B)
+```
+
+#### 6.4 Sparse Merkle Tree Definition (Normative)
+
+This KIP defines `SMT_Root` as a fixed-depth (256) sparse Merkle tree:
+
+1. Keys are 256-bit strings (`lane_key`), interpreted MSB-first as a path.
+2. Leaves exist at depth 256 and hold `leaf_hash_lane` (32 bytes) for active lanes; all other leaves are empty.
+3. Empty leaf hash is `EMPTY_0 = ZERO_HASH`.
+4. Internal empty node hash at height `i+1` is:
+
+```
+EMPTY_{i+1} = H_node(EMPTY_i || EMPTY_i)
+```
+
+5. A non-empty internal node hash is:
+
+```
+node_hash = H_node(left_child_hash || right_child_hash)
+```
+
+6. The empty-tree root is `EMPTY_256`.
+
+The root is the hash of the top node after setting all active leaves and filling all other subtrees with their corresponding `EMPTY_i` values.
+
+#### 6.5 Additional Committed Data (Normative)
+
+This KIP additionally commits (i) accepting-block header context and (ii) miner payloads from all mergeset blocks.
+
+##### 6.5.1 Accepting Block Context Commitment
+
+Upper layers often need a verifiable "clock" and height-like indices relative to `SeqCommit(B)`.
+
+Define:
+
+```
+MergesetContextHash(B) =
+    H_mergeset_context(
+        le_u64(B.header.timestamp)
+        || le_u64(B.header.daa_score)
+        || le_u64(B.header.blue_score)
+    )
+```
+
+`MergesetContextHash(B)` is committed both as part of `SeqStateRoot(B)` and inside each touched lane-tip update in `B`.
+
+##### 6.5.2 Miner Payload Commitment (Mergeset Blocks)
+
+To support based zk systems, this KIP commits raw coinbase payload bytes from all mergeset blocks of the accepting block `B`, including blocks whose coinbase transactions are not accepted.
+
+Rationale:
+
+* Non-selected-parent coinbase transactions are not accepted into `AcceptedTxList(B)`, but their coinbase payloads still carry consensus-relevant data: the accepting block's reward construction uses mergeset coinbase payload fields (e.g., payout destination data).
+* In practice, coinbase payloads are also the conventional place where miners signal extra metadata (e.g., software/pool identity), so these payload bytes can be relevant for L2 applications.
+* Therefore, this KIP commits these payload bytes via a dedicated block-level path, rather than through accepted-transaction sequencing.
+* Each committed payload is bound to block identity (`X.hash`) and `blue_work` to provide secure topological metadata.
+
+For each mergeset block `X`:
+
+* Let `payload_bytes(X)` be the raw payload bytes of the coinbase transaction of `X`.
+* Consensus rule update: for coinbase payload bytes, the legacy hard size limit is relaxed for miner-payload use, and the payload segment above that legacy limit is charged via transient mass.
+
+For each mergeset block `X`, define:
+
+```
+miner_payload_hash(X) = H_miner_payload(payload_bytes(X))
+
+miner_payload_leaf(X) = H_miner_payload_leaf(
+    X.hash
+    || blue_work_encoding(X.header.blue_work)
+    || miner_payload_hash(X)
+)
+```
+
+Let `MinerPayloadLeaves(B)` be the list of `miner_payload_leaf(X)` over all included mergeset blocks `X`, ordered by the deterministic mergeset traversal order used by consensus (selected parent first, then the remaining mergeset blocks in consensus topological order).
+
+Define:
+
+```
+MinerPayloadRoot(B) = MerkleRoot(MinerPayloadLeaves(B))
+```
+
+Merkle-root branching uses `H_seq` semantics (Section 4.2).
+
+#### 6.6 Sequencing State Root (Normative)
+
+Define:
+
+$$
+\mathrm{SeqStateRoot}(B) =
+H_{\mathrm{seq}}\Big(
+\mathrm{ActiveLanesRoot}(B),
+H_{\mathrm{seq}}(\mathrm{MergesetContextHash}(B), \mathrm{MinerPayloadRoot}(B))
+\Big).
+$$
+
+Notes:
+
+* `ActiveLanesRoot(B)` is a direct child of `SeqStateRoot(B)`.
+* `MergesetContextHash(B)` and `MinerPayloadRoot(B)` are committed as the right child hash.
+
+#### 6.7 Sequencing Commitment Recurrence (Normative)
+
+Define:
+
+$$
+\mathrm{SeqCommit}(B) =
+H_{\mathrm{seq}}\big(\mathrm{SeqCommit}(\mathrm{parent}(B)), \mathrm{SeqStateRoot}(B)\big).
+$$
+
+where `parent(B)` is `B`'s selected parent.
+
+Notes:
+
+* `SeqCommit(B)` is chained through selected-parent ancestry (KIP-15 style recurrence).
+* `SeqStateRoot(B)` is not directly exposed in the header; it is committed by `SeqCommit(B)`.
+* `ActiveLanesRoot(B)` is not directly exposed in the header; it is committed by `SeqStateRoot(B)` and therefore by `SeqCommit(B)`.
+
+### 7. Script Semantics
+
+`OpChainblockSeqCommit` (aka `OpChainBlockHistoryRoot` in [4, 5]) returns the 32-byte commitment value stored in the header field `accepted_id_merkle_root` of a chain block, subject to existing chain-ancestor and depth checks.
+
+This KIP defines post-activation `accepted_id_merkle_root` semantics for `OpChainblockSeqCommit`.
+
+### 8. Reorg-Safe Incremental Maintenance
+
+Implementations maintain sequencing commitment state incrementally via reversible per-block diffs.
+
+#### 8.1 Diff Content
+
+For each chain block `B`, define `SeqCommitDiff(B)` containing:
+
+1. lane mutations:
+
+   * `(lane, old_record_opt, new_record_opt)` for every inserted, updated, or removed lane.
+2. purge-index mutations:
+
+   * insert, update, and delete mutations in the score index for all touched/purged lanes.
+3. optional root transition cache:
+
+   * `old_root`, `new_root` for fast rollback/apply paths.
+
+#### 8.2 Reorg Operations
+
+Given a selected-parent reorg:
+
+1. walk down the old chain path and reverse `SeqCommitDiff`s in reverse order.
+2. walk up the new chain path and apply `SeqCommitDiff`s in forward order.
+
+This mirrors the existing UTXO-diff strategy and avoids full-state recomputation.
+
+### 9. Purge Index (Oldest-First / Heap-Oriented)
+
+Implementations provide oldest-score-first access for purge processing, equivalent to:
+
+1. `peek_oldest_score()`
+2. `pop_oldest_while(score <= purge_cutoff)`
+
+#### 9.1 On-Disk Ordered Index (RocksDB-Friendly)
+
+The canonical index is persisted in score order, enabling iterator-based popping without full scans.
+
+Recommended key layout:
+
+```
+LastTouchByScoreKey =
+    PREFIX_LAST_TOUCH_BY_SCORE
+    || be_u64(last_touch_blue_score)
+    || lane_key
+```
+
+Where:
+
+* `be_u64` is big-endian encoding.
+* `lane_key` disambiguates collisions for equal scores.
+
+Rationale:
+
+* RocksDB keys are lexicographically ordered.
+* With `be_u64(score)`, forward iteration yields oldest scores first.
+
+Equivalent encodings are allowed if they preserve deterministic oldest-first extraction semantics.
+
+#### 9.2 In-Memory Cache
+
+An implementation may maintain an in-memory min-heap over `(last_touch_blue_score, lane_key)` for hot-path purge checks.
+
+The heap is a cache/hint layer only; canonical correctness is defined by persisted state. Heap entries can become stale under updates/reorgs, so candidates popped from heap are validated against current persisted lane records before deletion.
+
+#### 9.3 Reorg and Diff Requirements
+
+All index mutations (insert/update/delete in `LastTouchByScore`) are part of `SeqCommitDiff` and are reversible under reorg.
+
+#### 9.4 IBD Bootstrap at Pruning Point (Normative Guidance)
+
+IBD from the pruning point (PP) must provide enough sequencing-commitment state for a new node to continue normal chain-block processing from PP onward.
+
+At PP, an implementation must have (or reconstruct) the following minimum data:
+
+* Full active-lane leaf data at PP (`lane_id_bytes`, `lane_tip_hash`, `last_touch_blue_score` for every active lane), sufficient to reconstruct `ActiveLanesRoot(PP)` in full.
+* `SeqCommit(parent(PP))` (equivalently, `PP` selected-parent `accepted_id_merkle_root`).
+* `MergesetContextHash(PP)` and `MinerPayloadRoot(PP)` (or equivalent raw data to deterministically recompute them).
+
+These are sufficient to verify `SeqStateRoot(PP)` and then verify `PP.accepted_id_merkle_root = SeqCommit(PP)` by the recurrence in Section 6.7.
+
+From that verified PP state, a node processes subsequent chain blocks by the same incremental rules in Sections 5-9 (touch/update/purge + diff maintenance).
+
+Operational note:
+
+* Implementations should retain the PP active set analogously to PP UTXO-set retention, and when PP advances, update it by advancing over sequencing-commitment diffs from the old PP to the new PP.
+* Alternatively, an implementation may reconstruct the PP active set in linear time using the optional persistent witness-store structure (Section 11).
+
+## Informative: Proving and Witness Operations
+
+Sections 10 and 11 describe proving-oriented usage patterns and optional witness-serving infrastructure. They explain how to consume the committed structure, but do not add consensus rules beyond Sections 1-9.
+
+### 10. Complexity
+
+Let:
+
+* $n = |AcceptedTxList(B)|$
+* $t = |Touched(B)|$
+* $p =$ number of purged lanes at $B$
+
+Then:
+
+* Grouping activity by lane is $O(n)$.
+* Updating tips is $O(t)$.
+* Purge checks with the ordered index are $O(p \log |ActiveLanes|)$.
+* SMT update is $O((t+p)\log(2^{256})) = O((t+p)\cdot 256) = O(t+p)$ with a large constant factor (256 levels).
+
+#### 10.1 Global Order Reconstruction
+
+If an upper layer needs global order reconstruction, it can reconstruct it by collecting the per-lane transaction sets and sorting by $`\mathrm{merge\_idx}`$ within the accepting block $B$. Verifying this reconstruction requires lane witnesses under the committed $SeqCommit(B)$ anchor and proving the relevant active-lanes SMT diff (or an equivalent witness relation) between anchors. This can be done by tracking (or recomputing) active-lanes SMT updates, or via the optional persistent witness-store approach in Section 11.
+
+#### 10.2 Two-Anchor Lane Proof Model
+
+For lane-local proving, the intended model is:
+
+1. provide two global anchors: $SeqCommit(B_{start})$ and $SeqCommit(B_{end})$;
+2. provide lane-inclusion witnesses for lane $\ell$ under both anchors (via $ActiveLanesRoot$ / $SeqStateRoot$);
+3. provide a compressed lane-diff witness from $`\mathrm{lane\_tip}(\ell, B_{\text{start}})`$ to $`\mathrm{lane\_tip}(\ell, B_{\text{end}})`$.
+
+The lane-diff witness size is proportional to lane activity between anchors, so this path is $O(a)$ rather than $O(\Delta B)$, where $a$ is app activity and $\Delta B$ is the number of chain blocks between anchors.
+
+Including $MergesetContextHash(B)$ in touched lane-tip updates is what makes accepting-block clock/context available on the lane-local path without forcing per-block global sequencing commitment processing.
+
+Miner payloads remain a block-level commitment ($MinerPayloadRoot(B)$). Apps that rely on this data still track block-level witnesses across intermediate chain blocks.
+
+#### 10.3 Reactivated Lane Proof Pattern
+
+For a lane that was purged and later re-appears, proving continuity typically needs both lane inclusion and lane non-inclusion witnesses:
+
+1. inclusion at the old anchor for the last pre-purge lane tip;
+2. non-inclusion checkpoints for $`\mathrm{lane\_key}(\ell)`$ under $ActiveLanesRoot$ while iterating the selected-parent $SeqCommit$ chain, with at least one checkpoint per $F$ blue-score window;
+3. inclusion at/after reactivation for the new lane tip anchored by $SeqCommit(parent(B_{reactivate}))$.
+
+Each non-inclusion checkpoint at blue score $s$ certifies inactivity for the preceding $F$-window ($[s-F, s]$) by the purge rule, so exclusion proofs do not need to be repeated inside that covered segment.
+
+This checkpoint pattern shows that no committed intermediate lane tip for $\ell$ exists between the old tip and the reactivation event.
+
+### 11. Optional Persistent Witness Store
+
+Clients (e.g., zk provers) may need inclusion and non-inclusion witnesses for a lane under older anchors (e.g., “5 hours ago”). Requiring each client to track the SMT live is heavy, and requiring nodes to rewind or replay diffs per witness request is also heavy. An optional auxiliary indexing layer can reconstruct witnesses directly from stored commitment structure.
+
+Implementation hints:
+
+* Maintain a unified, content-addressed commitment-node store:
+  `node_hash -> (left_child_hash, right_child_hash)`
+  covering both `H_seq` nodes (sequencing commitment and state roots) and SMT internal nodes (`H_node` under `ActiveLanesRoot`).
+
+* Witnesses can then be reconstructed directly from a header anchor `accepted_id_merkle_root = SeqCommit(B)` by descending the stored commitment DAG to the relevant subtree root (e.g., `ActiveLanesRoot(B)`; the descent from `SeqCommit(B)` to `ActiveLanesRoot(B)` follows a fixed path: right child to `SeqStateRoot(B)`, then left child to `ActiveLanesRoot(B)`, before the key-driven SMT path), and then following the SMT path for `lane_key(lane)` while collecting siblings.
+
+* Empty subtree hashes (`EMPTY_i`) are computable from the spec; the store only needs to retain non-empty nodes.
+
+Pruning and cleanup:
+
+* GC-like reference counting: maintain `refcount[node_hash]` alongside `node_hash -> (left,right)`.
+
+* Cleanup rule: on first insertion of `node_hash -> (left,right)` (i.e., if `node_hash` is not already present), increment `refcount[left]` and `refcount[right]`. Separately, treat every retained header anchor (`accepted_id_merkle_root`) as one additional reference to its root (increment on retention, decrement on prune), even if the root node already exists. When a header is pruned, decrement the root’s refcount; whenever a refcount hits zero, delete that node and recursively decrement its children. This layer is optional and does not replace reorg diffs for hot-path consensus maintenance.
+
+## Future Compatibility with vProgs CD
+
+This KIP is designed to remain compatible with a future full vProgs CD specification.
+
+Expected direction:
+
+* Account-level lanes may use a richer diff-style update rule (CD-like, with transaction vertices and account vertices).
+* Subnet-based lanes defined by this KIP remain unchanged, so zk provers built over the current subnet-lane logic can continue to operate as-is after a CD upgrade.
+* A full CD model may allow re-anchoring to a previously proven lane/account state, instead of always falling back to `SeqCommit(parent(B))` when state is absent from the active set.
+
+This section is informative only; it does not change the normative subnet-lane rules specified above.
+
+## Relationship to Covenants++ Workstream
+
+This KIP is a standalone consensus specification for partitioned sequencing commitments.
+
+Within the Covenants++ workstream, it complements KIP-16, KIP-17, and KIP-20. TN12 (the experimental testnet for Covenants++) already includes those KIPs and `OpChainblockSeqCommit` (earlier named `OpChainBlockHistoryRoot`, see [4, 5]). This KIP specifies the commitment semantics consumed by that opcode.
+
+## Backward Compatibility
+
+* This KIP is a consensus-changing hard fork: post-activation blocks are not consensus-compatible with nodes that do not implement these rules.
+* Post-activation, `accepted_id_merkle_root` follows `SeqCommit(B)` as defined here, coinbase payload bytes above the legacy hard size limit are admitted and charged via transient mass, and `OpChainblockSeqCommit` consumes this commitment path.
+
+## Why SMT
+
+Sparse authenticated map vs dense tree: this commitment tracks a sparse key-value map over lane IDs, with updates driven by touched/purged lanes. Dense tree representations are not practical here because diff/update work scales with global key-space structure rather than with per-block mutations.
+
+SMT vs Patricia: both SMT and Patricia-style sparse tries are viable and have similar asymptotic update properties (`O(mutations)` per block). This KIP chooses SMT for operational simplicity and proof regularity: implementation is simpler, and fixed-shape proofs are more uniform for verifier behavior and zk-circuit design.
+
+Implementation note: storage/IO overhead can be reduced with known sparse-tree optimization techniques (see [6]).
+
+## References
+
+[1] KIP-15: Canonical Transaction Ordering and Sequencing Commitments.
+[2] Subnets sequencing commitments (original seed to this design): [https://research.kas.pa/t/subnets-sequencing-commitments/274](https://research.kas.pa/t/subnets-sequencing-commitments/274)
+[3] vProgs yellow paper: [https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf](https://github.com/kaspanet/research/blob/main/vProgs/vProgs_yellow_paper.pdf)
+[4] On the design of based zk-rollups over Kaspa's UTXO-based DAG consensus: [https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208](https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208)
+[5] L1/L2 canonical bridge entry/exit mechanism: [https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258](https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258)
+[6] Optimizing Sparse Merkle Trees: [https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751](https://ethresear.ch/t/optimizing-sparse-merkle-trees/3751)

--- a/kip-0021.md
+++ b/kip-0021.md
@@ -197,6 +197,7 @@ Domain tags:
 | `H_activity_root` | `"SeqCommitActivityRoot"` |
 | `H_leaf` | `"SeqCommitActiveLeaf"` |
 | `H_node` | `"SeqCommitActiveNode"` |
+| `H_collapsed` | `"SeqCommitActiveCollapsedNode"` |
 | `H_seq` | `"SeqCommitmentMerkleBranchHash"` |
 
 `H_seq` is the same branch hasher domain separator used by the currently deployed post-covenants sequencing commitment path (`SeqCommitmentMerkleBranchHash`). This KIP formalizes that behavior and extends it with lane/state commitments.
@@ -444,26 +445,49 @@ ActiveLanesRoot(B) = SMT_Root({ lane_key(lane_id) -> leaf_hash(lane_id) | lane_i
 
 #### 6.4 Sparse Merkle Tree Definition (Normative)
 
-This KIP defines `SMT_Root` as a fixed-depth (256) sparse Merkle tree:
+This KIP defines `SMT_Root` as a 256-bit sparse Merkle map with collapsed single-leaf subtrees.
 
-1. Keys are 256-bit strings (`lane_key`), interpreted MSB-first as a path.
-2. Leaves exist at depth 256 and hold `leaf_hash(lane_id)` (32 bytes) for active lanes; all other leaves are empty.
-3. Empty leaf hash is `EMPTY_0 = ZERO_HASH`.
-4. Internal empty node hash at height `i+1` is:
+Keys are 256-bit strings (`lane_key`), interpreted MSB-first as a path. Empty subtree hashes are defined by:
+
+```
+EMPTY_0 = ZERO_HASH
+```
+
+and:
 
 ```
 EMPTY_{i+1} = H_node(EMPTY_i || EMPTY_i)
 ```
 
-5. A non-empty internal node hash is:
+Let `SubRoot(d, M)` be the root of the subtree at bit depth `d`, where `M` is the set of active entries whose keys share that subtree prefix.
+
+1. If `M` is empty:
+
+   ```
+   SubRoot(d, M) = EMPTY_{256-d}
+   ```
+
+2. If `M` contains exactly one entry `key -> leaf_hash`:
+
+   ```
+   SubRoot(d, M) = H_collapsed(key || leaf_hash)
+   ```
+
+3. Otherwise, split `M` by bit `d` of `key` into `M_left` and `M_right`:
+
+   ```
+   SubRoot(d, M) = H_node(SubRoot(d+1, M_left) || SubRoot(d+1, M_right))
+   ```
+
+Then:
 
 ```
-node_hash = H_node(left_child_hash || right_child_hash)
+SMT_Root(M) = SubRoot(0, M)
 ```
 
-6. The empty-tree root is `EMPTY_256`.
+The collapsed case is part of the consensus root semantics, not only a storage optimization. It avoids committing a chain of empty siblings below a subtree that contains a single active lane, while the full 256-bit key remains committed inside `H_collapsed`.
 
-The root is the hash of the top node after setting all active leaves and filling all other subtrees with their corresponding `EMPTY_i` values.
+Rationale: `lane_key` values are hashes, so active lane keys are expected to branch like uniformly distributed 256-bit strings. Long shared-prefix collisions are therefore rare, and deliberately constructing them is bounded by the difficulty of finding suitable `H_lane_key` preimages. The subnetwork ID rules further restrict that preimage space. In normal operation, collapsed single-leaf subtrees make inclusion/exclusion witnesses scale with the branching depth of the actual active set, effectively `O(log n)`, and make the tree representation scale as `O(n log n)`, where `n` is the number of active entries. Without collapsed single-leaf subtrees, the corresponding factors are tied to the fixed 256-bit key depth.
 
 #### 6.5 Additional Committed Data (Normative)
 

--- a/kip-0021/impl-spec.md
+++ b/kip-0021/impl-spec.md
@@ -2,12 +2,12 @@
 
 Status: Reserved companion document.
 
-This companion document is reserved for the rusty-kaspa implementation of KIP-21. It does not change the consensus rules in [KIP-21](../kip-0021.md).
+This companion document is reserved for conceptual rusty-kaspa implementation notes around KIP-21, including incremental state maintenance, witness-oriented data retention, pruning/reorg handling, and sync import/export choices. It does not change the consensus rules in [KIP-21](../kip-0021.md).
 
 Reserved scope:
 
-* versioned SMT state and caches
-* per-block metadata retained by rusty-kaspa
+* incremental SMT state maintenance
+* data retained for witness construction
 * pruning and reorg maintenance
 * pruning-point SMT import/export
 * IBD wire shape and validation flow

--- a/kip-0021/impl-spec.md
+++ b/kip-0021/impl-spec.md
@@ -1,0 +1,14 @@
+# KIP-21 rusty-kaspa Implementation Spec
+
+Status: placeholder.
+
+This companion document will describe the rusty-kaspa implementation of KIP-21 without changing the consensus rules in [KIP-21](../kip-0021.md).
+
+Planned scope:
+
+* versioned SMT state and caches
+* per-block metadata retained by rusty-kaspa
+* pruning and reorg maintenance
+* pruning-point SMT import/export
+* IBD wire shape and validation flow
+

--- a/kip-0021/impl-spec.md
+++ b/kip-0021/impl-spec.md
@@ -1,14 +1,13 @@
 # KIP-21 rusty-kaspa Implementation Spec
 
-Status: placeholder.
+Status: Reserved companion document.
 
-This companion document will describe the rusty-kaspa implementation of KIP-21 without changing the consensus rules in [KIP-21](../kip-0021.md).
+This companion document is reserved for the rusty-kaspa implementation of KIP-21. It does not change the consensus rules in [KIP-21](../kip-0021.md).
 
-Planned scope:
+Reserved scope:
 
 * versioned SMT state and caches
 * per-block metadata retained by rusty-kaspa
 * pruning and reorg maintenance
 * pruning-point SMT import/export
 * IBD wire shape and validation flow
-

--- a/kip-0021/proving-spec.md
+++ b/kip-0021/proving-spec.md
@@ -1,0 +1,14 @@
+# KIP-21 Proving Spec
+
+Status: placeholder.
+
+This companion document will describe proving and witness algorithms that consume KIP-21 commitments. It is not itself a consensus specification unless explicitly incorporated by the main KIP.
+
+Planned scope:
+
+* lane activity proofs
+* inactive-lane and reactivation proofs
+* inactivity shortcut usage
+* guest algorithms
+* witness formats and node-serving expectations
+

--- a/kip-0021/proving-spec.md
+++ b/kip-0021/proving-spec.md
@@ -4,6 +4,8 @@ Status: Reserved companion document.
 
 This companion document is reserved for proving and witness algorithms that consume KIP-21 commitments. It is not itself a consensus specification unless explicitly incorporated by the main KIP.
 
+It will guide provers on what Kaspa L1 commits to long term, and how to avoid making zk guests depend on commitment-structure details that may change unless the application explicitly needs those details.
+
 Reserved scope:
 
 * lane activity proofs

--- a/kip-0021/proving-spec.md
+++ b/kip-0021/proving-spec.md
@@ -1,14 +1,13 @@
 # KIP-21 Proving Spec
 
-Status: placeholder.
+Status: Reserved companion document.
 
-This companion document will describe proving and witness algorithms that consume KIP-21 commitments. It is not itself a consensus specification unless explicitly incorporated by the main KIP.
+This companion document is reserved for proving and witness algorithms that consume KIP-21 commitments. It is not itself a consensus specification unless explicitly incorporated by the main KIP.
 
-Planned scope:
+Reserved scope:
 
 * lane activity proofs
 * inactive-lane and reactivation proofs
 * inactivity shortcut usage
 * guest algorithms
 * witness formats and node-serving expectations
-

--- a/kip-0021/seqcommit-accessor.md
+++ b/kip-0021/seqcommit-accessor.md
@@ -1,15 +1,95 @@
 # KIP-21 Seqcommit Accessor
 
-Status: placeholder.
+Status: Companion document.
 
-This companion document will describe the script-facing seqcommit accessor model around `OpChainblockSeqCommit`.
+This document describes the script-facing accessor for KIP-21 sequencing
+commitments. The consensus commitment itself is specified in
+[KIP-21](../kip-0021.md).
 
-Planned scope:
+## Background
 
-* opcode semantics
-* selected-parent point of view
-* depth threshold rules
-* clean handling of DAG reorgs
-* headers-proof requirements during IBD
-* guest-facing usage considerations
+Based zk applications use L1 ordering as the source of truth for the data they
+must execute. A typical state-transition transaction spends an old
+state-commitment UTXO, proves an application transition, and creates a new
+state-commitment UTXO. The script or covenant logic must therefore be able to
+check that the claimed new state is anchored to a real L1 chain-block
+sequencing commitment.
 
+`OpChainblockSeqCommit` is that script-facing anchor. It lets a script read the
+seqcommit of a recent selected-parent-chain block and compare it with the public
+state-transition data committed by the application proof. This is the successor
+of the `OpChainBlockHistoryRoot` idea described in the based-apps background
+posts ([based zk-rollups](https://research.kas.pa/t/on-the-design-of-based-zk-rollups-over-kaspas-utxo-based-dag-consensus/208),
+[canonical bridge](https://research.kas.pa/t/l1-l2-canonical-bridge-entry-exit-mechanism/258)).
+
+## Opcode Mechanics
+
+`OpChainblockSeqCommit` consumes one 32-byte block hash from the stack and
+pushes the 32-byte sequencing commitment of that chain block:
+
+```
+input:  block_hash
+output: SeqCommit(block_hash)
+```
+
+The returned value is the target header's `accepted_id_merkle_root`, interpreted
+post-KIP-21 as `SeqCommit(target)`.
+
+The opcode is evaluated from a selected-parent point of view. For a transaction
+validated while constructing or validating a chain block `B`, that point of view
+is `selected_parent(B)`. The opcode succeeds only if the requested block:
+
+1. is known to the node from this point of view;
+2. is on the selected-parent chain of the point-of-view block;
+3. is within the seqcommit access threshold; and
+4. already has KIP-21 `accepted_id_merkle_root` semantics.
+
+If any condition fails, script validation fails.
+
+## Access Threshold
+
+Let `P` be the selected-parent point of view and let `X` be the requested chain
+block. The accessor admits `X` only when:
+
+```
+X.blue_score + F > P.blue_score
+```
+
+Equivalently, scripts can access seqcommits from the last `F` blue-score units
+only. For the deployed parameters, `F` is the finality depth, corresponding to
+about 12 hours of target block time.
+
+This restriction keeps script-visible header access strictly below the pruning
+period. Among other reasons, this bound determines the selected-parent-chain
+header segment that a pruning-point syncer must provide below the pruning point:
+the segment must cover the possible seqcommit accessor range needed at the
+boundary.
+
+## Lagging Provers
+
+Based applications whose provers stop producing updates for longer than the
+access threshold cannot resume by directly asking L1 script for an old anchor.
+They must first catch up to a recent anchor that is still within the accessible
+range.
+
+This does not prevent proving longer historical spans. A prover can prove an
+arbitrarily long span as long as it has the required data and witnesses; the
+threshold only restricts which historical seqcommit values can be read directly
+by script at validation time. Long-span proving and inactivity shortcuts are
+covered in [Proving Spec](proving-spec.md).
+
+## Reorg Behavior
+
+The opcode never gives access to an arbitrary DAG block. It only gives access to
+headers on the selected-parent chain of the current point of view.
+
+If a transaction is reorged and later validated through a different
+selected-parent chain, the same opcode call is re-evaluated from the new point of
+view. If the requested block is no longer on that selected-parent chain, or is
+outside the access threshold, the transaction fails under the new chain. The UTXO
+state then rolls back to the last shared selected-parent-chain block in the usual
+way.
+
+This makes seqcommit access deterministic under DAG reorgs: the commitment read
+by script is always relative to the selected-parent chain that is actually being
+validated.

--- a/kip-0021/seqcommit-accessor.md
+++ b/kip-0021/seqcommit-accessor.md
@@ -1,0 +1,15 @@
+# KIP-21 Seqcommit Accessor
+
+Status: placeholder.
+
+This companion document will describe the script-facing seqcommit accessor model around `OpChainblockSeqCommit`.
+
+Planned scope:
+
+* opcode semantics
+* selected-parent point of view
+* depth threshold rules
+* clean handling of DAG reorgs
+* headers-proof requirements during IBD
+* guest-facing usage considerations
+


### PR DESCRIPTION
### Summary
This PR adds KIP-21 as a draft consensus spec for replacing the current linear per-block seqcommit recurrence with a partitioned, lane-based commitment scheme.

The design keeps a single header commitment (`accepted_id_merkle_root`) while enabling lane-local proving that scales with lane activity (`O(activity)`), via two global anchors plus lane-local witnesses/diff.

Scheme illustration:

```text
Global chain:  S0 -> S1 -> S2 -> ... -> Sn
                 |    |              |
                 v    v              v
               A0    A1             An      (A = ActiveLanesRoot)

Lane L proof:
  inclusion(L, A0) ---- lane-local compressed transition ---- inclusion(L, An)
```

### This PR includes
- Defines lane extraction and lane-tip state transition rules.
- Defines `ActiveLanesRoot` as an SMT over active lane tips.
- Defines `SeqStateRoot` and selected-parent recurrence for `SeqCommit(B)`.
- Preserves the ability to reconstruct global sequencing order from committed lane activity using `merge_idx` plus lane witnesses/SMT-diff proofs under `SeqCommit` anchors.
- Commits accepting-block context (`timestamp`, `daa_score`, `blue_score`).
- Commits mergeset miner payloads (including non-accepted mergeset coinbase payloads) with block hash + blue work binding.
- Defines purge rules and oldest-first purge index behavior.
- Defines reorg-safe incremental maintenance via reversible diffs.
- Adds proving guidance:
  - global order reconstruction notes,
  - two-anchor lane proof model,
  - reactivated-lane non-inclusion pattern,
  - optional persistent witness store.

For prior research context, see "Subnets sequencing commitments": https://research.kas.pa/t/subnets-sequencing-commitments/274