### PR TITLE
KIP-24: Transaction Version 1: New Fields and Hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Kaspa Improvement Proposals (KIPs) describe standard proposals for the Kaspa net
 | [16](kip-0016.md) | Consensus, Script Engine | ZK Precompile Opcode | Alexander Safstrom | Implemented and activated in TN10 |
 | [20](kip-0020.md) | Consensus, Script Engine | Covenant IDs | Michael Sutton | Implemented and activated in TN10 |
 | [21](kip-0021.md) | Consensus, Chain-Block UTXO Validation | Partitioned Sequencing Commitment with O(activity) Proving | Michael Sutton, Maxim Biryukov, Hans Moog | Implemented and activated in TN10 |
-| [24](kip-0024.md) | Consensus, Applications | Transaction ID v1 Hashing (BLAKE3, payload/rest split) | Maxim Biryukov | Implemented |
+| [24](kip-0024.md) | Consensus, Applications | Transaction Version 1: New Fields and Hashing | Maxim Biryukov | Implemented |

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Kaspa Improvement Proposals (KIPs) describe standard proposals for the Kaspa net
 | [13](kip-0013.md) | Consensus | Transient Storage Handling | Michael Sutton, coderofstuff | Active |
 | [14](kip-0014.md) | Consensus | The Crescendo Hardfork | Michael Sutton | Active |
 | [15](kip-0015.md) | Consensus | Canonical Transaction Ordering and Sequencing Commitments | Mike Zak, Ro Ma | Active |
+| [24](kip-0024.md) | Consensus, Applications | Transaction ID v1 Hashing (BLAKE3, payload/rest split) | Maxim Biryukov | Implemented |

--- a/kip-0024.md
+++ b/kip-0024.md
@@ -23,7 +23,8 @@ Version 1 adds three field-level changes over version 0:
 
 Alongside these fields, version 1 changes how the transaction **ID** (txid) is computed.
 Version 0 keeps its existing `BLAKE2b` txid over the full serialized transaction (signature
-scripts replaced by empty arrays). Version 1 instead computes its txid with `BLAKE3` over a
+scripts replaced by empty arrays and the mass commitment excluded). Version 1 instead
+computes its txid with `BLAKE3` over a
 two-component structure: `txid = H(payload_digest || rest_digest)`, hashing the payload
 independently from the rest of the body.
 
@@ -70,7 +71,8 @@ Three design principles drive how the new fields are hashed:
 
 ## Hashing cost and the hash function
 
-Kaspa's legacy txid is a single `BLAKE2b` pass over the serialized transaction. The txid
+Kaspa's legacy txid is a single `BLAKE2b` pass over the serialized transaction, with
+signature scripts emptied and the mass commitment excluded. The txid
 hash is exercised in two very different cost domains, and they do not agree on which hash is
 cheapest. The choice has to be made with both in view.
 
@@ -164,11 +166,14 @@ application **lanes** in [KIP-21](kip-0021.md) (partitioned sequencing commitmen
 **covenant** output fields in [KIP-20](kip-0020.md) (covenant IDs). The relevant use cases:
 
 - A ZK guest program (or any verifier) can be handed `rest_digest` plus the raw payload,
-  recompute `payload_digest`, and prove that a specific payload leads to a given txid,
-  which in turn is a leaf of the block's `accepted_id_merkle_root` (the sequencing
-  commitment, KIP-15). L2 executors can thus filter / interpret transactions by payload
-  while proving the link to L1 acceptance, without transferring or re-hashing the full
-  transaction body.
+  recompute `payload_digest`, and prove that a specific payload leads to a given txid. That
+  txid is in turn committed by the block's `accepted_id_merkle_root`, which post-Toccata is
+  the partitioned sequencing commitment of [KIP-21](kip-0021.md) rather than a flat
+  [KIP-15](kip-0015.md) Merkle tree of txids: the txid enters through a lane **activity
+  leaf** `H(tx_id || le_u16(version) || le_u32(merge_idx))`, nested through the lane's
+  activity and tip into the SMT / state root and the selected-parent chain. L2 executors
+  can thus filter / interpret transactions by payload while proving the link to L1
+  acceptance, without transferring or re-hashing the full transaction body.
 - Conversely, a verifier can be shown that a transaction is *not* relevant (e.g. its
   payload is empty, or belongs to another application lane, KIP-21) and skip it cheaply,
   by revealing only the digests rather than the full transaction.
@@ -244,8 +249,12 @@ version may use ([KIP-21](kip-0021.md) subnetwork shape rules):
   non-zero namespace byte. This shape is only valid for **version >= 1**.
 
 So in practice a version 0 transaction must use the native (or coinbase) subnetwork, and
-only a version 1 transaction may carry a non-native user-lane `subnetwork_id` and its
-associated lane `gas`. The lane / gas semantics are specified in [KIP-21](kip-0021.md).
+only a version 1 transaction may carry a non-native user-lane `subnetwork_id`. The `gas`
+field follows the same gating and is checked separately: a version 0 transaction must have
+`gas == 0`, and even a version 1 transaction must keep `gas == 0` on the reserved system
+shapes (the 19-byte zero suffix, i.e. native / coinbase); only a version 1 user-lane
+transaction may carry non-zero `gas`. The lane / gas semantics are specified in
+[KIP-21](kip-0021.md).
 
 ## Field summary
 
@@ -254,7 +263,7 @@ associated lane `gas`. The lane / gas semantics are specified in [KIP-21](kip-00
 | input resource budget       | sig-op count (`u8`)         | compute budget (`u16`)                   |
 | output covenant binding     | not allowed                 | optional `(authorizing_input, covenant_id)` |
 | subnetwork                  | native / coinbase only      | also user lanes `[ns(4), 0×16]`          |
-| gas                         | effectively unused (native) | lane gas (KIP-21)                        |
+| gas                         | must be `0`                 | lane gas on user lanes; `0` on system shapes (KIP-21) |
 | txid hash function          | `BLAKE2b`, flat             | `BLAKE3`, payload/rest split             |
 
 # Specification
@@ -428,8 +437,12 @@ or adjust them before mining without changing transaction identity.
 
 ## Signature hashing (sighash)
 
-The sighash is what a spender signs (`TransactionSigningHash`, `BLAKE2b`). Its v1 treatment
-of the new fields is:
+The sighash is what a spender signs. The base (Schnorr) sighash is `TransactionSigningHash`,
+`BLAKE2b`; the ECDSA sighash is computed by wrapping that base sighash in one further
+`TransactionSigningHashECDSA` (`SHA-256`) pass over the 32-byte Schnorr result. The
+field-level treatment described below is identical for both paths (ECDSA only adds the outer
+wrap), so the rest of this section speaks of "the sighash" without distinguishing them. Its
+v1 treatment of the new fields is:
 
 - **Resource budget is not committed in v1.** Version 0 commits the per-input sig-op counts
   twice (a `sig_op_counts_hash` over all inputs, plus the current input's sig-op count in
@@ -595,6 +608,14 @@ Empty payload, comparing schemes:
 | v1 concat-of-leaves (BLAKE3)    | ~690-810 ns |
 | v1 full Merkle tree (BLAKE3)    | ~838 ns  |
 
+Only the `v0 legacy` and `v1 flat BLAKE3 (payload/rest)` rows correspond to schemes that
+shipped, and only those are reproducible from the current `tx_id_bench` in the repository.
+The other three rows (`v0 with BLAKE3`, `v1 concat-of-leaves`, `v1 full Merkle tree`) come
+from one-off design-exploration benchmarks run while choosing the scheme; they are recorded
+here for the design rationale but are not part of the committed benchmark suite, so
+reproducing them requires reconstructing those throwaway benches rather than running the
+current one.
+
 The `v0 with BLAKE3` row applies BLAKE3 to the unchanged v0 layout; it isolates the
 hash-function change from the structural change, showing BLAKE3 alone saves ~20% before any
 restructuring (it is not a candidate scheme, since it would silently re-derive every v0
@@ -668,25 +689,6 @@ The current implementation lives in:
 - `crypto/hashes/src/hashers.rs`: the keyed `BLAKE3` hashers `PayloadDigest`,
   `TransactionRest`, `TransactionV1Id` and the `blake3_hasher!` macro defining their
   domain-keyed construction.
-
-## Test vectors
-
-The `tests` module in `consensus/core/src/hashing/tx.rs` is the canonical source of txid /
-`tx::hash` test vectors. `test_zero_payload_digest` pins `ZERO_PAYLOAD_DIGEST`, and
-`test_transaction_hashing` cases #10 through #14 cover version 1 transactions, including the
-invariants that the transaction mass and the per-input compute budget / sig-op count affect
-`tx::hash` but not the txid. The sighash invariants (v1 commits neither sig-op count nor
-compute budget, while covenant output fields are committed) are exercised by
-`test_signature_hash` in `consensus/core/src/hashing/sighash.rs` (the
-`native-v1-all-0-modify-*` cases). Independent implementations should reproduce those
-expected values.
-
-Between them these cover an empty-payload v1 transaction (#11), a non-empty-payload v1
-transaction (#10), and a pair where changing the per-input compute budget changes `tx::hash`
-while leaving the txid identical (#11 vs #12). A dedicated covenant-output v1 vector is not
-yet present in the canonical tests; until one is added, an independent implementation should
-construct its own from the [v1 output encoding](#rest-preimage) rules and the `hash_output`
-covenant branch.
 
 # Acknowledgements
 

--- a/kip-0024.md
+++ b/kip-0024.md
@@ -1,7 +1,7 @@
 ```
 KIP: 24
 Layer: Consensus (hard fork), Applications
-Title: Transaction ID v1 Hashing (BLAKE3, payload/rest split)
+Title: Transaction Version 1: New Fields and Hashing
 Type: Consensus change (transaction format)
 Author: Maxim Biryukov (@biryukovmaxim)
 Created: 2026-01-27
@@ -10,35 +10,69 @@ Status: Implemented
 
 # Abstract
 
-This KIP defines a new transaction ID (txid) computation for version 1 transactions.
-Version 0 transactions keep their existing txid, computed with `BLAKE2b` over the full
-serialized transaction (signature scripts replaced by empty arrays). Version 1
-transactions instead compute their txid with `BLAKE3` over a two-component structure:
-the txid is the hash of a `payload_digest` concatenated with a `rest_digest`, where the
-payload is hashed independently from the rest of the transaction body.
+This KIP specifies version 1 transactions: the new fields they may carry and how all
+three transaction hashing contexts treat them.
 
-The change is motivated by (i) the move to `BLAKE3`, which is markedly faster than
-`BLAKE2b` on large inputs and slightly faster on the small inputs typical of payment
-transactions, and (ii) the desire to commit to the payload as a separate, addressable
-component so that ZK guest programs and L2/based executors can prove statements about a
-transaction's payload (or prove that a payload can be skipped) without bringing the full
-transaction body into the proof. A version 1 transaction is required for the covenant
-fields introduced alongside this work, so the txid for version 1 differs from version 0
-regardless; this KIP fixes how that new txid is defined.
+Version 1 adds three field-level changes over version 0:
 
-Version 0 transactions and existing clients are unaffected. Any client that builds
-version 1 transactions must adopt the new algorithm, dispatched on the transaction
-`version` field.
+- a per-input **compute budget** (`u16`) that replaces the version 0 **sig-op count**
+  (`u8`) as the input's committed resource budget,
+- an optional per-output **covenant binding** (`authorizing_input`, `covenant_id`), and
+- the ability to use a non-native **user-lane subnetwork** (with its associated `gas`),
+  which version 0 transactions are not allowed to use.
+
+Alongside these fields, version 1 changes how the transaction **ID** (txid) is computed.
+Version 0 keeps its existing `BLAKE2b` txid over the full serialized transaction (signature
+scripts replaced by empty arrays). Version 1 instead computes its txid with `BLAKE3` over a
+two-component structure: `txid = H(payload_digest || rest_digest)`, hashing the payload
+independently from the rest of the body.
+
+The txid change is motivated by (i) the move to `BLAKE3`, markedly faster than `BLAKE2b` on
+large inputs and slightly faster on the small inputs typical of payments, and (ii) the
+desire to commit to the payload as a separate, addressable component so that ZK guest
+programs and L2/based executors can prove statements about a transaction's payload (or that
+it can be skipped) without bringing the full transaction body into the proof.
+
+Three distinct hash contexts exist and are kept distinct throughout: the **txid** (identity,
+no resource commitments), the **transaction hash** `tx::hash` (block-level commitment,
+includes mass and resource budgets), and the **signature hash** (sighash, what a spender
+signs). This KIP states, field by field, how each context treats the new v1 fields, and
+contrasts that with v0.
+
+Version 0 transactions and existing clients are unaffected. Any client that builds version 1
+transactions must adopt the new fields and the new txid algorithm, both dispatched on the
+transaction `version` field.
 
 # Motivation
 
+## Why a new transaction version
+
+The Toccata hard fork introduces covenant-aware outputs ([KIP-20](kip-0020.md)), a
+runtime-metered script execution budget, and partitioned per-lane sequencing
+([KIP-21](kip-0021.md)). These require new transaction fields. Rather than mutate the
+version 0 format in place (which would silently re-derive every transaction's identity and
+break existing clients, signatures, and indexes), the new fields and the new hashing are
+gated behind a transaction **version bump**. A participant opts in by building a version 1
+transaction; version 0 stays byte-for-byte unchanged.
+
+Three design principles drive how the new fields are hashed:
+
+1. **Resource commitments must not change transaction identity.** Mass and the per-input
+   compute budget are miner/relay-side block-space accounting, not user intent. They are
+   excluded from the txid (as mass already was in v0) and, for v1, also from the sighash.
+   This lets mempool/miners fill or adjust these commitments before mining, as with storage
+   mass, without invalidating txids or signatures.
+2. **The payload should be a separately-provable component.** Splitting the payload into its
+   own digest lets payload-focused provers use that digest directly instead of
+   reconstructing and hashing the full transaction body.
+3. **Covenant fields are part of identity.** An output's covenant binding defines what the
+   output *is*, so it is committed by all three hash contexts.
+
 ## Hashing cost and the hash function
 
-Kaspa's legacy txid is a single `BLAKE2b` pass over the serialized transaction. Two
-forces pushed us to revisit this for version 1:
-
-The txid hash is exercised in two very different cost domains, and they do not agree on
-which hash is cheapest. The choice has to be made with both in view.
+Kaspa's legacy txid is a single `BLAKE2b` pass over the serialized transaction. The txid
+hash is exercised in two very different cost domains, and they do not agree on which hash is
+cheapest. The choice has to be made with both in view.
 
 ### Domain 1: native execution
 
@@ -48,7 +82,7 @@ magnitude. Here `BLAKE3` is the clear winner: `BLAKE2b` is a serial sponge, wher
 `BLAKE3` is a tree-based, SIMD-friendly hash whose throughput scales far better with input
 size. On a micro-benchmark of the txid computation, `BLAKE3` is slightly faster than
 `BLAKE2b` even for the empty/small-payload payment case (~300 ns vs ~370 ns) and
-increasingly faster as the payload grows, reaching ~3x at 256 KB (see
+increasingly faster as the payload grows, reaching ~3.2x at 256 KB (see
 [Benchmarks](#benchmarks)). SHA-256 is *slower* than both on a general-purpose CPU,
 and markedly so on platforms without SHA-NI hardware extensions.
 
@@ -120,7 +154,7 @@ Beyond raw speed, version 1 separates the **payload** from the **rest** of the
 transaction so that the payload commits to the txid through its own digest:
 
 ```
-txid_v1 = H_txid( payload_digest || rest_digest )
+txid_v1 = TransactionV1Id( payload_digest || rest_digest )
 ```
 
 This is what enables the sequencing-commitment use cases. The terms below come from
@@ -140,7 +174,88 @@ application **lanes** in [KIP-21](kip-0021.md) (partitioned sequencing commitmen
   by revealing only the digests rather than the full transaction.
 - The sequencing-commitment scheme still needs a cheap way to prove that a transaction is
   a version 0 transaction without bringing the full transaction; dispatching the txid
-  definition on `version` keeps that distinction explicit.
+  definition on `version` keeps that distinction explicit. [KIP-21](kip-0021.md) commits the
+  transaction version next to the transaction id in the sequencing commitment, so a prover
+  can target v1 semantics directly.
+- Because the v1 txid and the KIP-21 sequencing-commitment hashers are all `BLAKE3`, a
+  prover's full flow, from the payload/rest digests up through the sequencing commitment,
+  avoids `BLAKE2b` (comparatively ZK-unfriendly) as a proving primitive entirely. The
+  `BLAKE2b`-keyed `tx::hash` and sighash are not on this proving path, so the prover never
+  has to evaluate them. For L1 validation CPU the slight extra cost of the hierarchical
+  (two-leaf) txid is offset by `BLAKE3` being faster than `BLAKE2b` in native execution (see
+  [Benchmarks](#benchmarks)).
+
+# Version 1 transaction fields
+
+This section defines the field-level differences between version 0 and version 1. The
+encoding of each field into the various hash contexts is specified in
+[Specification](#specification).
+
+## Resource budget: compute budget vs sig-op count
+
+Every input carries exactly one *resource budget* value, but the kind differs by version:
+
+- **Version 0** inputs carry a **sig-op count** (`u8`). This is the only resource budget v0
+  supports: it is a static count of signature operations, used by mass accounting. The v0
+  format has no other notion of per-input execution cost.
+- **Version 1** inputs carry a **compute budget** (`u16`). Toccata makes script work far
+  more variable (richer opcodes, ZK precompiles), so a static sig-op count is too narrow.
+  The compute budget is a single runtime-metered execution budget covering sig-ops, stack
+  growth, hashing, and ZK work. Each compute-budget unit accounts for 10x less block space
+  than a legacy sig-op unit (100 vs 1000 grams), giving 10x finer resource resolution, while
+  the `u16` width still covers a large per-input range. The detailed unit ladder and metering
+  rules live in the forthcoming script-pricing KIP; this KIP only fixes how the budget is
+  hashed.
+
+These are mutually exclusive and version-gated in consensus: a version 1 transaction with a
+sig-op-count input is rejected, and a version 0 transaction with a compute-budget input is
+rejected. In the reference implementation this is the `TxInputMass` enum (`SigopCount(u8)`
+vs `ComputeBudget(u16)`), with `version_expects_compute_budget_field(version) = version >= 1`.
+
+## Covenant bindings on outputs
+
+Version 1 outputs may carry an optional **covenant binding**, absent in version 0:
+
+```
+CovenantBinding {
+    authorizing_input: u16,   // index of the input that authorizes creating this output
+    covenant_id:       Hash,  // 32-byte covenant identifier (KIP-20)
+}
+```
+
+A version 0 output is `{ value, script_public_key }`. A version 1 output is
+`{ value, script_public_key, covenant: Option<CovenantBinding> }`. The covenant semantics
+(what a `covenant_id` is, lineage, authorization rules) are defined in
+[KIP-20](kip-0020.md); this KIP only fixes how the binding is fed into the hashes. A version
+0 transaction carrying any covenant binding is rejected by consensus.
+
+Because a covenant binding defines what the output is, it is committed by **all three** hash
+contexts (txid, `tx::hash`, sighash), unlike the resource budget.
+
+## User-lane subnetworks and gas
+
+The 20-byte `subnetwork_id` and the `gas` field exist in the wire format for all versions
+and are hashed identically across versions, but consensus restricts which values a given
+version may use ([KIP-21](kip-0021.md) subnetwork shape rules):
+
+- The reserved shape `[x, 0×19]` (a single leading byte then 19 zero bytes) is allowed for
+  any version, but only for the **native** (`x = 0`) and **coinbase** (`x = 1`) first bytes.
+- A **user-lane** subnetwork has the shape `[namespace (4 bytes), 0×16]` with at least one
+  non-zero namespace byte. This shape is only valid for **version >= 1**.
+
+So in practice a version 0 transaction must use the native (or coinbase) subnetwork, and
+only a version 1 transaction may carry a non-native user-lane `subnetwork_id` and its
+associated lane `gas`. The lane / gas semantics are specified in [KIP-21](kip-0021.md).
+
+## Field summary
+
+| Field                       | v0                          | v1                                       |
+|-----------------------------|-----------------------------|------------------------------------------|
+| input resource budget       | sig-op count (`u8`)         | compute budget (`u16`)                   |
+| output covenant binding     | not allowed                 | optional `(authorizing_input, covenant_id)` |
+| subnetwork                  | native / coinbase only      | also user lanes `[ns(4), 0×16]`          |
+| gas                         | effectively unused (native) | lane gas (KIP-21)                        |
+| txid hash function          | `BLAKE2b`, flat             | `BLAKE3`, payload/rest split             |
 
 # Specification
 
@@ -170,7 +285,7 @@ commitment.
 
 ## Hashers and domain separation
 
-Three keyed `BLAKE3` hashers are introduced:
+Three keyed `BLAKE3` hashers are introduced for the v1 txid:
 
 | Hasher            | Domain key (ASCII)   | Role                                   |
 |-------------------|----------------------|----------------------------------------|
@@ -190,6 +305,10 @@ Keying each component with a distinct domain prevents cross-protocol and cross-c
 collisions (a `payload_digest` can never be mistaken for a `rest_digest` or a txid). As a
 self-check, `PayloadDigest::hash([])` must equal `ZERO_PAYLOAD_DIGEST` (see
 [Payload digest](#payload-digest)), which serves as a test vector for the key construction.
+
+`tx::hash` and the sighash continue to use the pre-existing `BLAKE2b`-keyed
+`TransactionHash` and `TransactionSigningHash` for all versions; only the txid moves to
+`BLAKE3`.
 
 ## Version 1 txid
 
@@ -239,7 +358,10 @@ It is exactly equal to `PayloadDigest::hash([])`:
 ### Rest preimage
 
 `rest_preimage(tx)` is the canonical transaction encoding with three exclusion flags set:
-`EXCLUDE_PAYLOAD | EXCLUDE_SIGNATURE_SCRIPT | EXCLUDE_MASS_COMMIT`.
+`EXCLUDE_PAYLOAD | EXCLUDE_SIGNATURE_SCRIPT | EXCLUDE_MASS_COMMIT`. Two of these flags each
+suppress more than their name suggests: `EXCLUDE_SIGNATURE_SCRIPT` drops both the signature
+script and the v0 sig-op count that is written together with it, and `EXCLUDE_MASS_COMMIT`
+drops both the transaction-level mass field and the per-input v1 compute budget.
 
 Encoding primitives (as implemented in `HasherExtensions`):
 
@@ -255,28 +377,105 @@ Concretely the preimage serializes, in order:
    - previous outpoint: `transaction_id` (32 bytes) then `index` (LE u32)
    - empty signature script (`write_var_bytes(&[])`, i.e. an 8-byte zero length), because
      `EXCLUDE_SIGNATURE_SCRIPT` is set
+   - the per-input **resource budget is excluded** here: the v0 sig-op count is written
+     only inside the signature-script branch (skipped under `EXCLUDE_SIGNATURE_SCRIPT`), and
+     the v1 compute budget is written only when the mass commitment is included (skipped
+     under `EXCLUDE_MASS_COMMIT`). Neither contributes to the txid, for either version.
    - `sequence` (LE u64)
-   - (per-input compute budget is part of the mass commitment and is **excluded**)
 3. output count via `write_len` (LE u64), then for each output:
    - `value` (LE u64)
    - script public key `version` (LE u16), then `script` via `write_var_bytes` (8-byte LE
      length then bytes)
-   - for `version >= 1`: a `bool` for whether a covenant is present, and if so
+   - for `version >= 1`: a `bool` for whether a covenant binding is present, and if so
      `authorizing_input` (LE u16) then `covenant_id` (32 bytes). The covenant fields and
      their semantics are defined in [KIP-20](kip-0020.md); this KIP only fixes how they are
-     fed into the txid preimage.
+     fed into the txid preimage. **The covenant binding *is* part of the txid.**
 4. `lock_time` (LE u64), `subnetwork_id` (20 bytes, raw, as stored), `gas` (LE u64)
 5. empty payload placeholder (`write_var_bytes(&[])`, i.e. an 8-byte zero length), because
    `EXCLUDE_PAYLOAD` is set
 6. (the mass commit field is **excluded**)
 
-Because the payload, signature scripts, and mass are all excluded from `rest_digest`, the
-payload contributes to the txid *only* through `payload_digest`, and signature
-malleability / mass commitments do not affect the txid (consistent with v0 semantics).
+Because the payload, signature scripts, and mass (transaction mass and the per-input
+compute budget / sig-op count) are all excluded from `rest_digest`, the payload contributes
+to the txid *only* through `payload_digest`, and signature malleability and resource
+commitments do not affect the txid (consistent with v0 semantics, and now extended to the
+new compute-budget field).
 
-Note that `tx.hash` (the distinct full-transaction hash used for block-level commitments,
-which does include signature scripts and the mass commitment) continues to use the
-`BLAKE2b`-keyed `TransactionHash` for all versions; this KIP changes only the txid.
+## Transaction hash (`tx::hash`)
+
+`tx::hash` is the full-transaction hash used for block-level commitments. It is distinct
+from the txid and is computed with the `BLAKE2b`-keyed `TransactionHash` for all versions,
+over the **FULL** encoding (no exclusion flags). The field order is the same as the rest
+preimage above, with the previously-excluded parts now present. The per-input layout, and
+in particular the position of the resource budget, differs by version:
+
+- **v0 input:** `previous_outpoint`, `signature_script` (`write_var_bytes`), sig-op count
+  (`u8`, immediately after the signature script), `sequence`.
+- **v1 input:** `previous_outpoint`, `signature_script` (`write_var_bytes`), `sequence`,
+  compute budget (`u16`, after `sequence`).
+
+Beyond the per-input fields:
+
+- **Covenant bindings** are included for `version >= 1`, identically to the txid preimage.
+- **Transaction mass** is committed: for v0 the mass field is written only when `mass > 0`
+  (the trigger is strictly `mass > 0`, not coinbase-ness; coinbase transactions are required
+  to have `mass == 0`, so their hash stays unchanged), and for `version >= 1` the mass field
+  is **always** written, making the encoding unambiguous and invertible for future fields.
+
+The design intent is that mass and resource budgets are a miner-side commitment about
+block-space usage, so they belong in `tx::hash` but not in the txid: mempool/miners can fill
+or adjust them before mining without changing transaction identity.
+
+## Signature hashing (sighash)
+
+The sighash is what a spender signs (`TransactionSigningHash`, `BLAKE2b`). Its v1 treatment
+of the new fields is:
+
+- **Resource budget is not committed in v1.** Version 0 commits the per-input sig-op counts
+  twice (a `sig_op_counts_hash` over all inputs, plus the current input's sig-op count in
+  the per-input section). Version 1 commits **neither** the sig-op count nor the compute
+  budget. This is a deliberate correction: putting resource commitments in the sighash was
+  the v0 mistake, not a property to preserve. It is what lets miners/relayers adjust the
+  compute budget before mining without invalidating the user's signature.
+- **Covenant output fields are committed in v1.** Outputs are hashed via the same
+  version-aware output encoding as `tx::hash` / the txid preimage, so for `version >= 1` the
+  covenant presence bit and (if present) `authorizing_input` + `covenant_id` are part of the
+  sighash. A signer therefore commits to the covenant bindings of the outputs it signs.
+- `version`, prev-outputs hash, sequences hash, the current input's outpoint / spk / amount
+  / sequence, the outputs hash (per sighash type), `lock_time`, `subnetwork_id`, `gas`,
+  payload hash, and the sighash type byte are committed as before. The version field is part
+  of the sighash, so a v0 and v1 transaction never collide on a signature.
+- The sighash's payload commitment is `payload_hash`: the `BLAKE2b`-keyed
+  `TransactionSigningHash` over `write_var_bytes(payload)` (short-circuited to the zero hash
+  for an empty payload on the native subnetwork). This is **not** the BLAKE3 `payload_digest`
+  used by the txid; the two are distinct constructs (different hash function and framing)
+  despite the similar names, and must not be interchanged.
+
+## Commitment matrix (v0 vs v1)
+
+Whether each field affects each hash context. Cell vocabulary: `yes` / `no` = committed or
+not; `excluded (empty)` = a fixed empty placeholder is written in place of the real value;
+`via digest` = the field enters the txid through `payload_digest` rather than the rest
+preimage; `n/a (signs prev spk)` = a signer commits to the spent output's script-public-key,
+not to its own signature script; `per type` = subject to the sighash-type
+(ALL / NONE / SINGLE / anyone-can-pay) rules.
+
+| Field                                 | txid                  | `tx::hash`            | sighash               |
+|---------------------------------------|-----------------------|-----------------------|-----------------------|
+| `version`                             | yes                   | yes                   | yes                   |
+| input outpoint / `sequence`           | yes                   | yes                   | yes                   |
+| input `signature_script`              | excluded (empty)      | yes                   | n/a (signs prev spk)  |
+| input sig-op count (v0)               | no                    | yes                   | yes                   |
+| input compute budget (v1)             | no                    | yes                   | **no**                |
+| output `value` / `script_public_key`  | yes                   | yes                   | yes (per type)        |
+| output covenant binding (v1)          | **yes**               | **yes**               | **yes**               |
+| `lock_time` / `subnetwork_id` / `gas` | yes                   | yes                   | yes                   |
+| `payload`                             | yes (via digest)      | yes (raw)             | yes (`payload_hash`)  |
+| transaction `mass`                    | no                    | yes (v1 always; v0 if >0) | no                |
+
+The two rows that change meaning from v0 to v1 are the input resource budget (sig-op count
+moves out of identity-and-sighash thinking and is replaced by a compute budget that is in
+`tx::hash` only) and the output covenant binding (new, committed everywhere).
 
 ## Exposed preimage / digest helpers
 
@@ -290,6 +489,25 @@ These let a verifier reconstruct `txid_v1 = TransactionV1Id(payload_digest || re
 from a payload and a rest digest (or vice versa) without the full transaction.
 
 # Rationale
+
+## Why resource commitments are excluded from txid and sighash
+
+The per-input compute budget (and, in v0, the sig-op count) is a commitment about how much
+block-space execution work the transaction is allowed, not a statement of user intent. Two
+consequences follow:
+
+- **It should not affect transaction identity.** Identity is fixed at signing time; a
+  block-space budget is a property the network meters. Excluding it from the txid (as mass
+  already was in v0) means the same logical transaction keeps one id regardless of how the
+  budget is later set.
+- **It should not be signed (v1).** v0 committed the sig-op count in the sighash, which
+  meant the budget was frozen at signing. v1 drops this so that mempool and miners can fill
+  or adjust the compute budget before mining (mirroring how storage-mass commitments are
+  handled) without invalidating the signature. The covenant fields, by contrast, *are*
+  user intent and remain signed.
+
+This is why `tx::hash` is the only context that commits the resource budget: it is precisely
+the block-level commitment where miner-side accounting belongs.
 
 ## Why a flat payload/rest split rather than a full Merkle tree
 
@@ -341,6 +559,12 @@ design and matches the convention used by the sequencing-commitment hashers.
   ~810 ns, i.e. the cost of the full tree without the membership-proof benefit. Rejected.
 - **Full binary Merkle tree over many leaves.** ~840 ns and added complexity for benefit
   only the payload split actually delivers. Rejected (see Rationale).
+- **Keep the v0 sig-op count and add a separate compute field.** Rejected: two parallel
+  resource fields complicate accounting and the sighash/identity question; the compute
+  budget is a strict generalization, so v1 replaces sig-op count outright.
+- **Commit the compute budget in the sighash (as v0 did for sig-op count).** Rejected: it
+  would freeze the budget at signing and prevent miner/relay adjustment, reintroducing the
+  exact v0 limitation this change fixes.
 - **Poseidon2 (algebraic hash).** Attractive for recursion-internal Merkle trees over
   field elements, but roughly 10x to 40x slower than CPU hashes when hashing raw bytes
   inside a RISC0 guest, and slow natively. Rejected for the byte-oriented transaction
@@ -348,13 +572,13 @@ design and matches the convention used by the sequencing-commitment hashers.
 - **SHA-256.** The strongest contender, and the cheapest hash *inside* the guest thanks to
   RISC0's SHA-256 precompile. It was not chosen because the decision spans two cost
   domains that rank the hashes oppositely (see
-  [Motivation](#motivation)): SHA-256 wins only in the guest, while it is slower than both
-  BLAKE2b and BLAKE3 on native hardware, where the overwhelming majority of txid
-  computations happen. Given that the payload/rest split keeps in-guest hashing small and
-  bounded, the constant native-execution cost dominates and `BLAKE3` wins overall. This
-  rejection is explicitly conditional: were the guest expected to hash large volumes of
-  data per proof, SHA-256 would likely become the better global choice and should be
-  reconsidered.
+  [Motivation](#hashing-cost-and-the-hash-function)): SHA-256 wins only in the guest, while
+  it is slower than both BLAKE2b and BLAKE3 on native hardware, where the overwhelming
+  majority of txid computations happen. Given that the payload/rest split keeps in-guest
+  hashing small and bounded, the constant native-execution cost dominates and `BLAKE3` wins
+  overall. This rejection is explicitly conditional: were the guest expected to hash large
+  volumes of data per proof, SHA-256 would likely become the better global choice and
+  should be reconsidered.
 
 # Benchmarks
 
@@ -371,7 +595,15 @@ Empty payload, comparing schemes:
 | v1 concat-of-leaves (BLAKE3)    | ~690-810 ns |
 | v1 full Merkle tree (BLAKE3)    | ~838 ns  |
 
-Cost vs payload size (`v0_legacy` BLAKE2b vs `v1_payload_rest` BLAKE3):
+The `v0 with BLAKE3` row applies BLAKE3 to the unchanged v0 layout; it isolates the
+hash-function change from the structural change, showing BLAKE3 alone saves ~20% before any
+restructuring (it is not a candidate scheme, since it would silently re-derive every v0
+txid).
+
+Cost vs payload size (`v0_legacy` BLAKE2b vs `v1_payload_rest` BLAKE3). The absolute figures
+below come from a different benchmark run / transaction shape than the table above, so the
+empty-payload numbers differ slightly (e.g. ~448 ns vs ~369 ns for v0 legacy); the ratios
+are the point:
 
 | Payload size | v0 legacy | v1 payload/rest | speedup |
 |--------------|-----------|-----------------|---------|
@@ -388,47 +620,76 @@ internal chunking and SIMD parallelism.
 
 # Backwards compatibility
 
-This is a consensus change requiring a hard fork. Activation is tied to the same hard fork
-that introduces version 1 transactions and the covenant fields ([KIP-20](kip-0020.md));
-the concrete activation height / network schedule is set by that umbrella hard fork rather
-than fixed here.
+This is a consensus change requiring a hard fork. Activation is tied to the same Toccata
+hard fork that introduces version 1 transactions, the covenant fields
+([KIP-20](kip-0020.md)), the compute-budget pricing, and the lane subnetworks
+([KIP-21](kip-0021.md)); the concrete activation height / network schedule is set by that
+umbrella hard fork rather than fixed here.
 
-The full version 0 txid and `tx.hash` definitions are not restated in this KIP (they are
+The full version 0 txid and `tx::hash` definitions are not restated in this KIP (they are
 unchanged); an independent client implementing only v1 still needs them, and can find both
 in `consensus/core/src/hashing/tx.rs` (`id_v0`, `hash`).
 
-- **Version 0 transactions are unchanged**, byte-for-byte, in both `txid` and `hash`. Old
-  clients that only build or read v0 transactions are unaffected.
-- **Version 1 transactions** (introduced together with the covenant fields) compute their
-  txid with the new scheme. Any wallet, indexer, explorer, or library that constructs,
-  signs, or identifies v1 transactions must implement `id_v1` and dispatch on the
-  transaction `version` field.
+- **Version 0 transactions are unchanged**, byte-for-byte, in `txid`, `tx::hash`, and
+  sighash. Old clients that only build or read v0 transactions are unaffected.
+- **Version 1 transactions** carry the new fields and compute their txid with the new
+  scheme. Any wallet, indexer, explorer, or library that constructs, signs, or identifies
+  v1 transactions must implement the new fields, `id_v1`, and the v1 sighash/`tx::hash`
+  encodings, all dispatched on the transaction `version` field.
 - Because v1 is a new transaction version, no existing transaction's identifier changes;
-  the new algorithm applies only to transactions that opt into version 1.
+  the new fields and algorithm apply only to transactions that opt into version 1.
 
 # Reference implementation
 
-Introduced in [rusty-kaspa PR #849](https://github.com/kaspanet/rusty-kaspa/pull/849)
-("introduce new method of calculation txid for transaction of version 1"). The current
-implementation lives in:
+The version 1 transaction format and hashing were introduced across several rusty-kaspa
+PRs:
+
+- [PR #835](https://github.com/kaspanet/rusty-kaspa/pull/835) — covenant-related fields in
+  transactions, UTXOs, PSKT, RPC, and JS bindings (the output `CovenantBinding`).
+- [PR #849](https://github.com/kaspanet/rusty-kaspa/pull/849) — the version 1 txid
+  computation (`BLAKE3` payload/rest split).
+- [PR #884](https://github.com/kaspanet/rusty-kaspa/pull/884) — granular script pricing and
+  the per-input `compute_budget` field for v1 transactions.
+- [PR #943](https://github.com/kaspanet/rusty-kaspa/pull/943) — KIP-21, including the
+  version-gated user-lane `subnetwork_id` shape rules.
+
+The current implementation lives in:
 
 - `consensus/core/src/hashing/tx.rs`: `id`, `id_v0`, `id_v1`, `payload_digest`,
-  `v1_rest_digest`, `transaction_v1_rest_preimage`, `write_rest_preimage`, and the
-  `ZERO_PAYLOAD_DIGEST` constant.
+  `v1_rest_digest`, `transaction_v1_rest_preimage`, `write_rest_preimage`, `write_input`,
+  `write_output`, and the `ZERO_PAYLOAD_DIGEST` constant.
+- `consensus/core/src/hashing/sighash.rs`: `calc_schnorr_signature_hash`, `hash_output`
+  (the v1-aware covenant / resource-budget sighash treatment).
+- `consensus/core/src/tx.rs`: `TxInputMass` (`SigopCount` / `ComputeBudget`),
+  `CovenantBinding`, `TransactionOutput.covenant`.
+- `consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs`:
+  `check_transaction_subnetwork`, `check_tx_version_specific_fields` (version-gating of the
+  new fields).
 - `crypto/hashes/src/hashers.rs`: the keyed `BLAKE3` hashers `PayloadDigest`,
   `TransactionRest`, `TransactionV1Id` and the `blake3_hasher!` macro defining their
   domain-keyed construction.
 
 ## Test vectors
 
-The `tests` module in `consensus/core/src/hashing/tx.rs` is the canonical source of test
-vectors. `test_zero_payload_digest` pins `ZERO_PAYLOAD_DIGEST`, and `test_transaction_hashing`
-cases #10 through #14 cover version 1 transactions (including the invariants that mass and
-per-input compute budget / sigop count affect `tx.hash` but not the txid). Independent
-implementations should reproduce those expected `id`/`hash` values.
+The `tests` module in `consensus/core/src/hashing/tx.rs` is the canonical source of txid /
+`tx::hash` test vectors. `test_zero_payload_digest` pins `ZERO_PAYLOAD_DIGEST`, and
+`test_transaction_hashing` cases #10 through #14 cover version 1 transactions, including the
+invariants that the transaction mass and the per-input compute budget / sig-op count affect
+`tx::hash` but not the txid. The sighash invariants (v1 commits neither sig-op count nor
+compute budget, while covenant output fields are committed) are exercised by
+`test_signature_hash` in `consensus/core/src/hashing/sighash.rs` (the
+`native-v1-all-0-modify-*` cases). Independent implementations should reproduce those
+expected values.
+
+Between them these cover an empty-payload v1 transaction (#11), a non-empty-payload v1
+transaction (#10), and a pair where changing the per-input compute budget changes `tx::hash`
+while leaving the txid identical (#11 vs #12). A dedicated covenant-output v1 vector is not
+yet present in the canonical tests; until one is added, an independent implementation should
+construct its own from the [v1 output encoding](#rest-preimage) rules and the `hash_output`
+covenant branch.
 
 # Acknowledgements
 
 Thanks to Michael Sutton <msutton@cs.huji.ac.il> and Ori Newman <orinewman1@gmail.com>
-(@someone235) for the design discussion that shaped the payload/rest split and the
-hash-function choice.
+(@someone235) for the design discussion that shaped the payload/rest split, the resource /
+identity separation, and the hash-function choice.

--- a/kip-0024.md
+++ b/kip-0024.md
@@ -1,0 +1,434 @@
+```
+KIP: 24
+Layer: Consensus (hard fork), Applications
+Title: Transaction ID v1 Hashing (BLAKE3, payload/rest split)
+Type: Consensus change (transaction format)
+Author: Maxim Biryukov (@biryukovmaxim)
+Created: 2026-01-27
+Status: Implemented
+```
+
+# Abstract
+
+This KIP defines a new transaction ID (txid) computation for version 1 transactions.
+Version 0 transactions keep their existing txid, computed with `BLAKE2b` over the full
+serialized transaction (signature scripts replaced by empty arrays). Version 1
+transactions instead compute their txid with `BLAKE3` over a two-component structure:
+the txid is the hash of a `payload_digest` concatenated with a `rest_digest`, where the
+payload is hashed independently from the rest of the transaction body.
+
+The change is motivated by (i) the move to `BLAKE3`, which is markedly faster than
+`BLAKE2b` on large inputs and slightly faster on the small inputs typical of payment
+transactions, and (ii) the desire to commit to the payload as a separate, addressable
+component so that ZK guest programs and L2/based executors can prove statements about a
+transaction's payload (or prove that a payload can be skipped) without bringing the full
+transaction body into the proof. A version 1 transaction is required for the covenant
+fields introduced alongside this work, so the txid for version 1 differs from version 0
+regardless; this KIP fixes how that new txid is defined.
+
+Version 0 transactions and existing clients are unaffected. Any client that builds
+version 1 transactions must adopt the new algorithm, dispatched on the transaction
+`version` field.
+
+# Motivation
+
+## Hashing cost and the hash function
+
+Kaspa's legacy txid is a single `BLAKE2b` pass over the serialized transaction. Two
+forces pushed us to revisit this for version 1:
+
+The txid hash is exercised in two very different cost domains, and they do not agree on
+which hash is cheapest. The choice has to be made with both in view.
+
+### Domain 1: native execution
+
+Every node, wallet, indexer, and miner computes txids on ordinary hardware, for every
+transaction, constantly. This path dominates total ecosystem hashing cost by orders of
+magnitude. Here `BLAKE3` is the clear winner: `BLAKE2b` is a serial sponge, whereas
+`BLAKE3` is a tree-based, SIMD-friendly hash whose throughput scales far better with input
+size. On a micro-benchmark of the txid computation, `BLAKE3` is slightly faster than
+`BLAKE2b` even for the empty/small-payload payment case (~300 ns vs ~370 ns) and
+increasingly faster as the payload grows, reaching ~3x at 256 KB (see
+[Benchmarks](#benchmarks)). SHA-256 is *slower* than both on a general-purpose CPU,
+and markedly so on platforms without SHA-NI hardware extensions.
+
+### Domain 2: ZK guest execution
+
+The longer-term motivation is the based-ZK covenant / sequencing-commitment milestone,
+where transaction hashing happens *inside* a RISC0 zkVM guest and every executed
+instruction must be proven. Here the ranking inverts. Measured cost of hashing 1 KB of
+state inside the guest:
+
+| Hash       | In-guest proving time |
+|------------|-----------------------|
+| SHA-256    | ~6.7 s                |
+| BLAKE3     | ~12 s                 |
+| BLAKE2b    | ~23 s                 |
+| Poseidon2  | ~250 s                |
+
+SHA-256 is the fastest because RISC0 ships a **SHA-256 precompile**: the compression
+function is implemented as a dedicated circuit baked into the zkVM (analogous to Intel
+SHA-NI on a real CPU), and a guest reaches it transparently through RISC0's patched `sha2`
+crate. `BLAKE3` and `BLAKE2b` have no such accelerator, so every XOR/rotate/add runs as
+ordinary RISC-V instructions that the prover must prove cycle by cycle, which is why they
+are ~2x and ~3.5x slower respectively. Poseidon2, despite being "cheap" in constraint
+count, is catastrophic here because it simulates large modular-field arithmetic in
+software on a 32-bit CPU. (See RISC0's precompiles documentation:
+<https://dev.risczero.com/api/zkvm/precompiles>.)
+
+### Resolving the two domains
+
+The two domains pull in opposite directions, so the decision is a genuine tradeoff rather
+than a clear win for either hash:
+
+- **Native cost is constant, ubiquitous, and unavoidable.** BLAKE3's advantage there
+  applies to every transaction on every machine forever, and is large on big payloads.
+- **In-guest cost falls only on provers**, who are specialized and amortize work, and the
+  payload/rest split is specifically designed so the guest re-hashes only a few 32-byte
+  digests per proof rather than full transaction bodies (see
+  [Payload as a separately-provable component](#payload-as-a-separately-provable-component)).
+  The in-guest measurements above are for 1 KB of state (where SHA-256 is ~1.8x faster than
+  BLAKE3); at the few-32-byte-digests scale the design targets, the absolute difference is
+  expected to be small, though this small-workload case has not been separately benchmarked
+  here. In all cases BLAKE3 remains roughly an order of magnitude ahead of the only
+  algebraic alternative.
+- **The SHA-256 precompile only accelerates SHA-256.** Pinning the consensus hash to one
+  prover's current accelerator set is a soft form of lock-in; BLAKE3 stays
+  cheapest-everywhere independent of proof system or RISC0 version.
+- **Different ZK frameworks favor different hashes.** The in-guest ranking is not a
+  universal fact about SHA-256; it is specific to RISC0's accelerator set. A RISC-V zkVM
+  with a SHA-256 precompile favors SHA-256, a STARK/AIR system with a small native field
+  may favor an arithmetization-friendly hash, and another framework may ship a BLAKE
+  accelerator instead. The consensus hash is fixed for the lifetime of the format, while
+  the ZK tooling around it will change and diversify. We should therefore optimize for a
+  hash that is *good enough in any guest* rather than optimal in one: BLAKE3 has no
+  precompile anywhere yet stays within a small constant factor of the accelerated path,
+  and is roughly an order of magnitude ahead of the algebraic alternatives across guests,
+  making it the safer choice against an unknown mix of future proving stacks.
+
+The conclusion is conditional, and worth stating plainly: **if the guest workload were
+expected to hash large volumes of data per proof, SHA-256 (with its precompile) would
+likely be the better global choice.** Because the intended design keeps in-guest hashing
+small and bounded, the constant native-execution win dominates, and `BLAKE3` is chosen for
+the whole new hashing surface (txid v1 and the sequencing-commitment hashers), keyed for
+domain separation. If future ZK designs shift large amounts of hashing into the guest,
+this tradeoff should be revisited rather than treated as settled.
+
+## Payload as a separately-provable component
+
+Beyond raw speed, version 1 separates the **payload** from the **rest** of the
+transaction so that the payload commits to the txid through its own digest:
+
+```
+txid_v1 = H_txid( payload_digest || rest_digest )
+```
+
+This is what enables the sequencing-commitment use cases. The terms below come from
+related KIPs: the **sequencing commitment** and `accepted_id_merkle_root` are defined in
+[KIP-15](kip-0015.md) (canonical transaction ordering and sequencing commitments),
+application **lanes** in [KIP-21](kip-0021.md) (partitioned sequencing commitment), and the
+**covenant** output fields in [KIP-20](kip-0020.md) (covenant IDs). The relevant use cases:
+
+- A ZK guest program (or any verifier) can be handed `rest_digest` plus the raw payload,
+  recompute `payload_digest`, and prove that a specific payload leads to a given txid,
+  which in turn is a leaf of the block's `accepted_id_merkle_root` (the sequencing
+  commitment, KIP-15). L2 executors can thus filter / interpret transactions by payload
+  while proving the link to L1 acceptance, without transferring or re-hashing the full
+  transaction body.
+- Conversely, a verifier can be shown that a transaction is *not* relevant (e.g. its
+  payload is empty, or belongs to another application lane, KIP-21) and skip it cheaply,
+  by revealing only the digests rather than the full transaction.
+- The sequencing-commitment scheme still needs a cheap way to prove that a transaction is
+  a version 0 transaction without bringing the full transaction; dispatching the txid
+  definition on `version` keeps that distinction explicit.
+
+# Specification
+
+## Versioned dispatch
+
+The txid is computed by version:
+
+```
+id(tx):
+    if tx.version == 0:  return id_v0(tx)   # legacy, unchanged
+    else:                return id_v1(tx)
+```
+
+This KIP specifies `id_v1`. `id_v0` is the pre-existing definition: a single
+`BLAKE2b`-keyed `TransactionID` hash over the transaction serialized with signature
+scripts replaced by empty byte arrays and the mass commitment excluded. It is retained
+verbatim so that existing transactions and clients are byte-for-byte unaffected.
+
+The new hashing is deliberately gated on a version bump rather than applied in place to all
+transactions. Changing the txid hash function without bumping the version would silently
+re-derive the identifier of every transaction, breaking existing clients, signatures, and
+indexes. By keeping v0 logic intact and introducing the new scheme only for v1, the change
+is non-breaking: a participant opts in by building a version 1 transaction. This is also
+why the txid definition keys off the `version` field, which [KIP-21](kip-0021.md) relies on
+to efficiently distinguish v0 from v1 transactions when proving over the sequencing
+commitment.
+
+## Hashers and domain separation
+
+Three keyed `BLAKE3` hashers are introduced:
+
+| Hasher            | Domain key (ASCII)   | Role                                   |
+|-------------------|----------------------|----------------------------------------|
+| `PayloadDigest`   | `"PayloadDigest"`    | hashes the raw payload bytes           |
+| `TransactionRest` | `"TransactionRest"`  | hashes the transaction body sans payload/sig/mass |
+| `TransactionV1Id` | `"TransactionV1Id"`  | combines the two digests into the txid |
+
+Each hasher is `BLAKE3` in **keyed mode** (`blake3::Hasher::new_keyed`) with the default
+**32-byte output**. The 32-byte key is constructed deterministically from the domain
+string: the ASCII bytes of the string are placed at the **start** of an all-zero 32-byte
+buffer, and the remaining trailing bytes stay zero (right zero-padding). For example
+`"PayloadDigest"` (13 bytes) yields the key `50 61 79 6c 6f 61 64 44 69 67 65 73 74` followed
+by 19 zero bytes. All three domain strings are well under 32 bytes; a domain string longer
+than 32 bytes is invalid.
+
+Keying each component with a distinct domain prevents cross-protocol and cross-component
+collisions (a `payload_digest` can never be mistaken for a `rest_digest` or a txid). As a
+self-check, `PayloadDigest::hash([])` must equal `ZERO_PAYLOAD_DIGEST` (see
+[Payload digest](#payload-digest)), which serves as a test vector for the key construction.
+
+## Version 1 txid
+
+```
+id_v1(tx):
+    payload_digest = payload_digest(tx.payload)
+    rest_digest    = TransactionRest( rest_preimage(tx) )
+    return TransactionV1Id( payload_digest || rest_digest )
+```
+
+Equivalently, the txid is the root of a minimal two-leaf tree, where one leaf hashes the
+payload and the other hashes everything else:
+
+```
+                    txid = TransactionV1Id(payload_digest || rest_digest)
+                   /                                                   \
+          payload_digest                                          rest_digest
+       PayloadDigest(payload)                              TransactionRest(rest_preimage)
+   (ZERO_PAYLOAD_DIGEST if payload empty)            (version, inputs, outputs, lock_time,
+                                                      subnetwork_id, gas; payload, signature
+                                                      scripts, and mass excluded)
+```
+
+This is the full hierarchy: the payload is split into its own leaf precisely so it can be
+proved or skipped independently, and the rest of the transaction is hashed flat into the
+second leaf. (The richer multi-leaf tree that was considered and rejected is in
+[Rationale](#why-a-flat-payloadrest-split-rather-than-a-full-merkle-tree).)
+
+### Payload digest
+
+```
+payload_digest(payload):
+    if payload.is_empty():  return ZERO_PAYLOAD_DIGEST
+    else:                   return PayloadDigest( payload )
+```
+
+`PayloadDigest(payload)` is the keyed `BLAKE3` hash of the raw payload bytes.
+
+`ZERO_PAYLOAD_DIGEST` is the precomputed `PayloadDigest` of the empty input, hard-coded as
+a constant so the common empty-payload payment transaction skips an actual hashing call.
+It is exactly equal to `PayloadDigest::hash([])`:
+
+```
+9c0ca2acb45e92ffe6ceb4ae29188b35c82d9676cdd3ce067fd6ccc30a9c4a38
+```
+
+### Rest preimage
+
+`rest_preimage(tx)` is the canonical transaction encoding with three exclusion flags set:
+`EXCLUDE_PAYLOAD | EXCLUDE_SIGNATURE_SCRIPT | EXCLUDE_MASS_COMMIT`.
+
+Encoding primitives (as implemented in `HasherExtensions`):
+
+- `write_len(n)` writes `n` as a **fixed 8-byte little-endian u64** (not a var-int).
+- `write_var_bytes(b)` writes `write_len(b.len())` (8-byte LE length) followed by the raw
+  bytes `b`. An empty value therefore encodes as 8 zero bytes and nothing else.
+- `write_bool` writes a single `0x00`/`0x01` byte; integers are written little-endian.
+
+Concretely the preimage serializes, in order:
+
+1. `version` (LE u16)
+2. input count via `write_len` (LE u64), then for each input:
+   - previous outpoint: `transaction_id` (32 bytes) then `index` (LE u32)
+   - empty signature script (`write_var_bytes(&[])`, i.e. an 8-byte zero length), because
+     `EXCLUDE_SIGNATURE_SCRIPT` is set
+   - `sequence` (LE u64)
+   - (per-input compute budget is part of the mass commitment and is **excluded**)
+3. output count via `write_len` (LE u64), then for each output:
+   - `value` (LE u64)
+   - script public key `version` (LE u16), then `script` via `write_var_bytes` (8-byte LE
+     length then bytes)
+   - for `version >= 1`: a `bool` for whether a covenant is present, and if so
+     `authorizing_input` (LE u16) then `covenant_id` (32 bytes). The covenant fields and
+     their semantics are defined in [KIP-20](kip-0020.md); this KIP only fixes how they are
+     fed into the txid preimage.
+4. `lock_time` (LE u64), `subnetwork_id` (20 bytes, raw, as stored), `gas` (LE u64)
+5. empty payload placeholder (`write_var_bytes(&[])`, i.e. an 8-byte zero length), because
+   `EXCLUDE_PAYLOAD` is set
+6. (the mass commit field is **excluded**)
+
+Because the payload, signature scripts, and mass are all excluded from `rest_digest`, the
+payload contributes to the txid *only* through `payload_digest`, and signature
+malleability / mass commitments do not affect the txid (consistent with v0 semantics).
+
+Note that `tx.hash` (the distinct full-transaction hash used for block-level commitments,
+which does include signature scripts and the mass commitment) continues to use the
+`BLAKE2b`-keyed `TransactionHash` for all versions; this KIP changes only the txid.
+
+## Exposed preimage / digest helpers
+
+To support the sequencing-commitment and ZK use cases, the implementation exposes:
+
+- `v1_rest_digest(tx) -> Hash`: the `rest_digest` for a v1 transaction.
+- `transaction_v1_rest_preimage(tx) -> Vec<u8>`: the exact `rest_preimage` byte string,
+  so a guest can be fed the preimage and recompute `rest_digest` itself.
+
+These let a verifier reconstruct `txid_v1 = TransactionV1Id(payload_digest || rest_digest)`
+from a payload and a rest digest (or vice versa) without the full transaction.
+
+# Rationale
+
+## Why a flat payload/rest split rather than a full Merkle tree
+
+An alternative scheme with a richer hierarchy was also considered: decomposing the
+transaction into several leaves (version/subnetwork/mass; input_len/output_len/lock_time/gas;
+payload_len/payload; outputs_tree_root/inputs_tree_root) and making the txid the root of a
+binary Merkle tree over them, so that any component could be proved with an `O(log n)`
+branch. It was declined due to its inefficiency relative to the negligible benefit it
+added (see below).
+
+```
+                          txid = H(Node0 || Node1)
+                       /                            \
+        Node0 = H(Leaf0||Leaf1)        Node1 = H(Leaf2||Leaf3)
+        /            \                  /                \
+   Leaf0          Leaf1            Leaf2              Leaf3
+ version||      input_len||     payload_len||     outputs_root||
+ subnet||mass   output_len||    payload          inputs_root
+                lock_time||gas
+```
+
+Benchmarking showed the full tree roughly **doubled** txid cost for the common case
+(~840 ns vs ~370 ns legacy) with little practical benefit, because:
+
+- The only decomposition with a concrete consumer is the **payload** (for L2 filtering and
+  ZK skip/inclusion). The remaining fields are almost always needed together.
+- A flat `H(payload_digest || rest_digest)` already gives the payload its own provable
+  digest, which is the property that matters, at essentially legacy cost.
+- Reusing BLAKE3's internal Merkle tree was rejected: its leaves are 1 KB chunks, which do
+  not align with transaction-field boundaries and so do not yield useful component proofs.
+
+The chosen scheme is therefore the minimal hierarchy: payload split out, everything else
+hashed flat as `rest`. This matches the "flat hierarchy like in sighash" preference raised
+in review and keeps the common-case cost at parity with the legacy txid.
+
+## Per-component domain separation
+
+Each leaf/component uses its own domain-keyed hasher rather than a shared hasher with a
+positional tag. This makes the construction collision-resistant across components by
+design and matches the convention used by the sequencing-commitment hashers.
+
+# Alternatives considered
+
+- **Keep BLAKE2b, no structural change.** Rejected: misses the throughput win on large
+  payloads and provides no payload-addressable digest for ZK/L2 use.
+- **Switch to BLAKE3 but hash the whole transaction flat (no payload split).** Fast, but
+  gives no separately-provable payload component, defeating the main motivation.
+- **Concatenate-then-hash all field leaves (`H(concat of leaves)`).** Benchmarked at
+  ~810 ns, i.e. the cost of the full tree without the membership-proof benefit. Rejected.
+- **Full binary Merkle tree over many leaves.** ~840 ns and added complexity for benefit
+  only the payload split actually delivers. Rejected (see Rationale).
+- **Poseidon2 (algebraic hash).** Attractive for recursion-internal Merkle trees over
+  field elements, but roughly 10x to 40x slower than CPU hashes when hashing raw bytes
+  inside a RISC0 guest, and slow natively. Rejected for the byte-oriented transaction
+  format.
+- **SHA-256.** The strongest contender, and the cheapest hash *inside* the guest thanks to
+  RISC0's SHA-256 precompile. It was not chosen because the decision spans two cost
+  domains that rank the hashes oppositely (see
+  [Motivation](#motivation)): SHA-256 wins only in the guest, while it is slower than both
+  BLAKE2b and BLAKE3 on native hardware, where the overwhelming majority of txid
+  computations happen. Given that the payload/rest split keeps in-guest hashing small and
+  bounded, the constant native-execution cost dominates and `BLAKE3` wins overall. This
+  rejection is explicitly conditional: were the guest expected to hash large volumes of
+  data per proof, SHA-256 would likely become the better global choice and should be
+  reconsidered.
+
+# Benchmarks
+
+Micro-benchmarks of a single txid computation (`kaspa-consensus-core`, `tx_id_bench`),
+1 input / 2 outputs.
+
+Empty payload, comparing schemes:
+
+| Scheme                          | Time     |
+|---------------------------------|----------|
+| v0 legacy (BLAKE2b)             | ~369 ns  |
+| v0 with BLAKE3                  | ~292 ns  |
+| v1 flat BLAKE3 (payload/rest)   | ~305-410 ns |
+| v1 concat-of-leaves (BLAKE3)    | ~690-810 ns |
+| v1 full Merkle tree (BLAKE3)    | ~838 ns  |
+
+Cost vs payload size (`v0_legacy` BLAKE2b vs `v1_payload_rest` BLAKE3):
+
+| Payload size | v0 legacy | v1 payload/rest | speedup |
+|--------------|-----------|-----------------|---------|
+| 0 B          | ~448 ns   | ~384 ns         | ~1.2x   |
+| 1 KB         | ~1.02 µs  | ~1.09 µs        | ~parity |
+| 4 KB         | ~2.96 µs  | ~1.53 µs        | ~1.9x   |
+| 64 KB        | ~41.0 µs  | ~13.8 µs        | ~3.0x   |
+| 256 KB       | ~161 µs   | ~51 µs          | ~3.2x   |
+
+For small payloads (the dominant payment case) fixed overhead dominates and the two are
+comparable; once payload size grows the legacy `O(n)` BLAKE2b pass falls behind BLAKE3,
+reaching ~3x faster at 256 KB. This is the expected behavior given BLAKE3's larger
+internal chunking and SIMD parallelism.
+
+# Backwards compatibility
+
+This is a consensus change requiring a hard fork. Activation is tied to the same hard fork
+that introduces version 1 transactions and the covenant fields ([KIP-20](kip-0020.md));
+the concrete activation height / network schedule is set by that umbrella hard fork rather
+than fixed here.
+
+The full version 0 txid and `tx.hash` definitions are not restated in this KIP (they are
+unchanged); an independent client implementing only v1 still needs them, and can find both
+in `consensus/core/src/hashing/tx.rs` (`id_v0`, `hash`).
+
+- **Version 0 transactions are unchanged**, byte-for-byte, in both `txid` and `hash`. Old
+  clients that only build or read v0 transactions are unaffected.
+- **Version 1 transactions** (introduced together with the covenant fields) compute their
+  txid with the new scheme. Any wallet, indexer, explorer, or library that constructs,
+  signs, or identifies v1 transactions must implement `id_v1` and dispatch on the
+  transaction `version` field.
+- Because v1 is a new transaction version, no existing transaction's identifier changes;
+  the new algorithm applies only to transactions that opt into version 1.
+
+# Reference implementation
+
+Introduced in [rusty-kaspa PR #849](https://github.com/kaspanet/rusty-kaspa/pull/849)
+("introduce new method of calculation txid for transaction of version 1"). The current
+implementation lives in:
+
+- `consensus/core/src/hashing/tx.rs`: `id`, `id_v0`, `id_v1`, `payload_digest`,
+  `v1_rest_digest`, `transaction_v1_rest_preimage`, `write_rest_preimage`, and the
+  `ZERO_PAYLOAD_DIGEST` constant.
+- `crypto/hashes/src/hashers.rs`: the keyed `BLAKE3` hashers `PayloadDigest`,
+  `TransactionRest`, `TransactionV1Id` and the `blake3_hasher!` macro defining their
+  domain-keyed construction.
+
+## Test vectors
+
+The `tests` module in `consensus/core/src/hashing/tx.rs` is the canonical source of test
+vectors. `test_zero_payload_digest` pins `ZERO_PAYLOAD_DIGEST`, and `test_transaction_hashing`
+cases #10 through #14 cover version 1 transactions (including the invariants that mass and
+per-input compute budget / sigop count affect `tx.hash` but not the txid). Independent
+implementations should reproduce those expected `id`/`hash` values.
+
+# Acknowledgements
+
+Thanks to Michael Sutton <msutton@cs.huji.ac.il> and Ori Newman <orinewman1@gmail.com>
+(@someone235) for the design discussion that shaped the payload/rest split and the
+hash-function choice.


### PR DESCRIPTION
## KIP-24: Transaction Version 1: New Fields and Hashing

Specifies version 1 transactions: the new fields they carry and how all three transaction hashing contexts treat them.

### Scope

**New v1 fields (vs v0):**
- per-input **compute budget** (`u16`) replacing the v0 **sig-op count** (`u8`) as the input's committed resource budget;
- optional per-output **covenant binding** (`authorizing_input`, `covenant_id`);
- non-native **user-lane subnetworks** (and their `gas`), which v0 transactions may not use.

**New v1 txid hashing:**
- `txid_v1 = TransactionV1Id(payload_digest || rest_digest)` using keyed `BLAKE3`, hashing the payload independently from the rest of the body so ZK/L2 provers can address (or skip) the payload without the full transaction.

**How each hash context treats the fields:** the KIP states, field by field, how the **txid** (identity), **`tx::hash`** (block-level commitment), and **sighash** (what a spender signs) handle the new v1 fields, with an explicit v0/v1 commitment matrix.

### Design highlights

- Resource commitments (mass, compute budget) are kept out of transaction identity and, for v1, out of the sighash, so miners/relayers can fill or adjust them before mining without invalidating txids or signatures (the deliberate fix from v0, where the sig-op count was committed in the sighash).
- Covenant bindings, being part of what an output *is*, are committed by all three contexts.
- The hash-function choice (`BLAKE3`) is presented as a two-domain tradeoff: native execution (where `BLAKE3` wins and dominates ecosystem cost) vs ZK-guest execution (where RISC0's SHA-256 precompile wins). The payload/rest split keeps in-guest hashing small, and the v1 txid plus the KIP-21 sequencing-commitment hashers are all `BLAKE3`, so a prover's full flow avoids `BLAKE2b`. The choice is explicitly conditional and documented as such.

### Status

Implemented in rusty-kaspa across PRs [#835](https://github.com/kaspanet/rusty-kaspa/pull/835) (covenant fields), [#849](https://github.com/kaspanet/rusty-kaspa/pull/849) (v1 txid), [#884](https://github.com/kaspanet/rusty-kaspa/pull/884) (compute budget), and [#943](https://github.com/kaspanet/rusty-kaspa/pull/943) (KIP-21 user-lane subnetworks). Verified against the current implementation in `consensus/core/src/hashing/{tx,sighash}.rs`, `consensus/core/src/tx.rs`, and the transaction validator.

### References

- [KIP-15](https://github.com/kaspanet/kips/blob/master/kip-0015.md) — canonical transaction ordering and sequencing commitments
- [KIP-20](https://github.com/kaspanet/kips/blob/master/kip-0020.md) — covenant IDs
- [KIP-21](https://github.com/kaspanet/kips/blob/master/kip-0021.md) — partitioned sequencing commitment, lanes, gas, subnetwork namespace
