### PR TITLE
KIP-0012: Specification for Browser Extension Wallet APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kaspa Improvement Proposals (KIPs) describe standard proposals for the Kaspa net
 | [6](kip-0006.md) | Consensus, Applications | Proof of Chain Membership (PoChM) | Shai Wyborski | Draft |
 | [9](kip-0009.md) | Consensus, Mempool, P2P | Extended mass formula for mitigating state bloat | Michael Sutton, Ori Newman, Shai Wyborski, Yonatan Sompolinsky | Active |
 | [10](kip-0010.md) | Consensus, Script Engine | New Transaction Opcodes for Enhanced Script Functionality | Maxim Biryukov, Ori Newman | Active |
+| [12](kip-0012.md) | Applications | Specification for Browser Extension Wallet APIs | aspect, starkbamse, KaffinPX, mattoo, IzioDev, Shawn Pearce | Draft |
 | [13](kip-0013.md) | Consensus | Transient Storage Handling | Michael Sutton, coderofstuff | Active |
 | [14](kip-0014.md) | Consensus | The Crescendo Hardfork | Michael Sutton | Active |
 | [15](kip-0015.md) | Consensus | Canonical Transaction Ordering and Sequencing Commitments | Mike Zak, Ro Ma | Active |

--- a/kip-0012.md
+++ b/kip-0012.md
@@ -1,0 +1,432 @@
+# KIP-0012: Specification for Browser Extension Wallet APIs
+
+<table>
+  <tr><td>Layer</td><td>WASM32 Wallet SDK, Browser Extension Wallet APIs</td></tr>
+  <tr><td>Title</td><td>Specification for Browser Extension Wallet APIs</td></tr>
+  <tr><td>Authors</td><td>@aspect, @starkbamse, @KaffinPX, @mattoo, @IzioDev, @ShawnPearce</td></tr>
+  <tr><td>Status</td><td>DRAFT</td></tr>
+</table>
+
+## Goals
+- **Standardize Wallet APIs**: Define how wallets expose their functionalities to web apps.
+- **Support Multiple Protocols**: Ensure compatibility with current and future Kaspa protocols.
+- **Interoperability**: Allow seamless interaction between wallets and web apps through a uniform API structure.
+
+## Motivation
+
+The Kaspa ecosystem is witnessing the emergence of several Browser Extension Wallet standards for interfacing with web applications. This KIP aims to standardize the methodology by which wallets expose themselves to and communicate with these web applications.
+
+Additionally, this KIP seeks to provide a common framework for wallets to showcase their capabilities, particularly in performing various functions and accommodating different emerging protocols. These protocols include, but are not limited to:
+
+- **KRC-20 protocol** by Kasplex
+- **KSC protocol** (future Sparkle Smart Contract assets)
+
+Covenant transactions enabled by the Toccata upgrade add one more requirement: A wallet must be able to sign only the inputs it owns in a transaction built by the web app, without touching inputs that are authorized by on-chain rules. This document specifies that signing mode as well (see [Transaction Signing for Covenants](#transaction-signing-for-covenants-signpskt)).
+
+This document is loosely based on Ethereum's [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963).
+
+## Key Definitions
+
+- **Wallet**: A browser extension capable of storing Kaspa-based assets.
+- **Web App**: A browser-accessible application interacting with the wallet to access stored funds and execute operations.
+
+## Specification
+
+**The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC-2119](https://datatracker.ietf.org/doc/html/rfc2119).**
+
+### Communication Events
+Wallets and web apps communicate through the browser's `window` object using `CustomEvent` objects.
+
+- **`kaspa:requestProvider`**: Request wallets to announce themselves.
+- **`kaspa:provider`**: Announces the wallet's presence to the web app.
+- **`kaspa:connect`**: Establishes connection between the wallet and the web app.
+- **`kaspa:requestAccounts`**: Requests the authorized account addresses. Establishes a connection like `kaspa:connect` and additionally returns the address list.
+- **`kaspa:chainId`**: Requests the wallet's current network id. This is read only.
+- **`kaspa:getPublicKey`**: Requests the active account's public key (hex).
+- **`kaspa:event`**: Used to send data from the wallet to the web app.
+- **`kaspa:disconnect`**: Terminates the connection between wallet and web app.
+- **`kaspa:send`**: Request to sign and broadcast a PSKB over the Kaspa network.
+- **`kaspa:sign`**: Request to sign a PSKB.
+- **`kaspa:broadcast`**: Request to broadcast a signed PSKB over the Kaspa network.
+- **`kaspa:signPersonal`**: Request to sign a personal message using [KIP-5](kip-0005.md).
+- **`kaspa:sendTransaction`**: Request to sign and broadcast a transaction over the Kaspa network.
+- **`kaspa:signTransaction`**: Request to sign a transaction.
+- **`kaspa:broadcastTransaction`**: Request to broadcast a signed transaction over the Kaspa network.
+- **`kaspa:signPskt`**: Request to sign only specific inputs of a transaction built by the web app (see [Transaction Signing for Covenants](#transaction-signing-for-covenants-signpskt)).
+
+The wallet **MUST NOT** react to any requests except the **`kaspa:connect`** and **`kaspa:requestAccounts`** events. Only after an explicit connection request **MAY** the wallet react to subsequent requests made by the **Web App**. As an exception, the wallet **MAY** answer **`kaspa:chainId`** before a connection, since the network id is not account-specific.
+
+### Example Event Flows
+
+The following is an example event flow of sending a transaction.
+
+|Sender||Event||Receiver|Interface|
+|---|--|---|---|---|---|
+| **Web App** | → | **Request Provider** (`kaspa:requestProvider`) | → | **Wallet** | `Notification`
+| **Wallet** | → | **Provide Information** (`kaspa:provider`) | → | **Web App** | `Notification`
+| **Web App** | → | **Connect** (`kaspa:connect`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Connect Confirmation** (`kaspa:event`) | → | **Web App** | `Response`
+| **Web App** | → | **Send & Sign PSKB** (`kaspa:send`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Send Response** (`kaspa:event`) | → | **Web App** | `Response`
+| **Web App / Wallet** | → | **Disconnect** (`kaspa:disconnect`) | → | **Wallet / Web App** | `Notification`
+
+|Sender||Event||Receiver|Interface|
+|---|--|---|---|---|---|
+| **Web App** | → | **Request Provider** (`kaspa:requestProvider`) | → | **Wallet** | `Notification`
+| **Wallet** | → | **Provide Information** (`kaspa:provider`) | → | **Web App** | `Notification`
+| **Web App** | → | **Connect** (`kaspa:connect`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Connect Confirmation** (`kaspa:event`) | → | **Web App** | `Response`
+| **Web App** | → | **Sign PSKB** (`kaspa:sign`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Send back signed PSKB** (`kaspa:event`) | → | **Web App** | `Response`
+| **Web App** | → | **Broadcast signed PSKB** (`kaspa:broadcast`) | → | **Wallet** | `Request`
+| **Web App / Wallet** | → | **Disconnect** (`kaspa:disconnect`) | → | **Wallet / Web App** | `Notification`
+
+The following flow was validated end to end on testnet-10 with a covenant dApp (a bonding-curve trade, where the transaction carries both covenant inputs and the user's own inputs):
+
+|Sender||Event||Receiver|Interface|
+|---|--|---|---|---|---|
+| **Web App** | → | **Request Provider** (`kaspa:requestProvider`) | → | **Wallet** | `Notification`
+| **Wallet** | → | **Provide Information** (`kaspa:provider`) | → | **Web App** | `Notification`
+| **Web App** | → | **Request Accounts** (`kaspa:requestAccounts`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Address list** (`kaspa:event`) | → | **Web App** | `Response`
+| **Web App** | → | **Sign specific inputs** (`kaspa:signPskt`) | → | **Wallet** | `Request`
+| **Wallet** | → | **Signed transaction** (`kaspa:event`) | → | **Web App** | `Response`
+
+### Interface Definitions
+
+```typescript
+export const KIP12_EVENT_METHOD = "kaspa:event" as const;
+
+export const KIP12_METHODS = [
+  "kaspa:connect",
+  "kaspa:disconnect",
+  "kaspa:requestAccounts",
+  "kaspa:chainId",
+  "kaspa:getPublicKey",
+  "kaspa:send",
+  "kaspa:sign",
+  "kaspa:broadcast",
+  "kaspa:signPersonal",
+  "kaspa:sendTransaction",
+  "kaspa:signTransaction",
+  "kaspa:broadcastTransaction",
+  "kaspa:signPskt",
+] as const;
+
+export type KIP12Method = (typeof KIP12_METHODS)[number];
+export type KIP12EventMethod = typeof KIP12_EVENT_METHOD;
+
+// Hex-encoded bytes / a serialized PSKB, as produced by the WASM SDK.
+export type HexString = string;
+export type PSKB = string;
+
+export interface KIP12ErrorPayload {
+  message: string;
+  code?: string | number;
+  details?: unknown;
+}
+
+// Amounts are sompi as a base-10 string. Floating-point KAS amounts MUST NOT be
+// used on the wire: IEEE-754 doubles cannot represent every sompi value exactly,
+// and a rounding error in an amount is a fund-safety defect.
+export interface KIP12SimpleTransfer {
+  to: string;
+  amountSompi: string;
+}
+
+// One input the web app asks the wallet to sign, by position.
+export interface KIP12SignInput {
+  index: number;
+  sighashType: number;
+}
+
+// `signPskt` argument: a Safe-JSON transaction plus the explicit list of inputs to sign.
+export interface KIP12SignPsktArg {
+  txJsonString: string;
+  options: { signInputs: KIP12SignInput[] };
+}
+
+export interface KIP12MethodArgs {
+  "kaspa:connect": [];
+  "kaspa:disconnect": [];
+  "kaspa:requestAccounts": [];
+  "kaspa:chainId": [];
+  "kaspa:getPublicKey": [];
+  "kaspa:send": [HexString];
+  "kaspa:sign": [PSKB];
+  "kaspa:broadcast": [HexString];
+  "kaspa:signPersonal": [string];
+  "kaspa:sendTransaction": [KIP12SimpleTransfer];
+  // safe JSON representation of the Transaction
+  "kaspa:signTransaction": [string];
+  "kaspa:broadcastTransaction": [HexString];
+  "kaspa:signPskt": [KIP12SignPsktArg];
+}
+
+export interface KIP12MethodResult {
+  "kaspa:connect": string;
+  "kaspa:disconnect": string;
+  // Returns array of addresses, no popup if already connected. A locked wallet
+  // MAY prompt the user to unlock, or reject with 4900.
+  "kaspa:requestAccounts": string[];
+  // Returns the current network identifier e.g. "mainnet" | "testnet-10" | "testnet-11"
+  "kaspa:chainId": string;
+  // Active account public key hex
+  "kaspa:getPublicKey": HexString;
+  "kaspa:send": HexString[];
+  "kaspa:sign": HexString;
+  "kaspa:broadcast": HexString;
+  "kaspa:signPersonal": HexString;
+  "kaspa:sendTransaction": HexString;
+  "kaspa:signTransaction": HexString;
+  "kaspa:broadcastTransaction": HexString;
+  // the re-serialized signed Safe-JSON transaction
+  "kaspa:signPskt": string;
+}
+
+export type KIP12Args<TMethod extends KIP12Method> = KIP12MethodArgs[TMethod];
+
+export type KIP12Result<TMethod extends KIP12Method> =
+  KIP12MethodResult[TMethod];
+
+export interface KIP12BaseMessage {
+  eventId: string;
+  extensionId?: string;
+}
+
+export interface KIP12RequestMessage<TMethod extends KIP12Method = KIP12Method>
+  extends KIP12BaseMessage {
+  method: TMethod;
+  args?: KIP12Args<TMethod>;
+}
+
+export interface KIP12EventSuccess<TData = unknown> extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data: TData;
+  error?: undefined;
+}
+
+export interface KIP12EventError extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data?: undefined;
+  error: KIP12ErrorPayload;
+}
+
+export type KIP12EventMessage<TData = unknown> =
+  | KIP12EventSuccess<TData>
+  | KIP12EventError;
+
+export type KIP12ExtensionMessage = KIP12RequestMessage | KIP12EventMessage;
+
+export interface KIP12ProviderInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly icon: string;
+  readonly methods: readonly KIP12Method[];
+  // UUIDv4, freshly generated per page load. Instance identity, used by web apps for dedupe.
+  readonly uuid: string;
+  // Reverse-DNS id, e.g. "com.kasware". STABLE across page loads; enables session restore.
+  readonly rdns?: string;
+}
+
+export interface KIP12Provider {
+  // Typed core. requestAccounts is the one REQUIRED provider method; web apps
+  // capability-check the rest (`typeof provider.signPskt === "function"`) and
+  // degrade gracefully when a method is absent.
+  requestAccounts(): Promise<string[]>;
+  getNetwork?(): Promise<string>;
+  getPublicKey?(): Promise<string>;
+  signMessage?(message: string): Promise<string>;
+  // Sign ONLY the listed inputs; all other inputs stay untouched.
+  signPskt?(arg: KIP12SignPsktArg): Promise<string>;
+  // Generic escape hatch for current and future protocol methods.
+  request?<TMethod extends KIP12Method>(
+    method: TMethod,
+    args: KIP12Args<TMethod>,
+  ): Promise<KIP12Result<TMethod>>;
+  connect?(): Promise<void>;
+  disconnect?(): Promise<void>;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  removeListener?(event: string, handler: (...args: unknown[]) => void): void;
+}
+```
+
+### Provider Info and Multi-Wallet Discovery
+
+The `detail` of a `kaspa:provider` event is `Object.freeze({ info, provider })`, as in the implementation example below. A few rules make this work with several wallets installed at once:
+
+- The wallet **MUST** announce once on load and **MUST** re-announce on every `kaspa:requestProvider`. A wallet that only replies to requests is invisible to a web app that requested before the wallet finished injecting; a wallet that only announces on load is invisible to a web app that loaded later.
+- `info.uuid` **MUST** be a fresh UUIDv4 per page load. Web apps **SHOULD** dedupe announcements by `info.rdns ?? info.uuid` (first announcement wins).
+- The wallet **SHOULD** provide a stable `rdns`. Without it a web app cannot re-match the wallet across page loads, so session restore will not work.
+- Freezing the detail protects a single announcement from being mutated in flight. It does **NOT** authenticate the announcer — any page script can announce any `name` or `rdns`. Web apps **MUST NOT** treat `name`, `icon`, or `rdns` as trust signals (see [Security Considerations](#security-considerations)).
+- There is no shared `window.kaspaProvider` global: with multiple wallets installed a shared global is last-write-wins. A wallet **MAY** expose a vendor-namespaced global (e.g. `window.riftProvider`), but web apps **MUST** discover wallets through the events above.
+
+### Transaction Signing for Covenants (signPskt)
+
+Covenant transactions (post-Toccata) carry inputs that are authorized by on-chain rules rather than by the user's key, a bonding curve, a pool, a covenant-owned UTXO. The web app builds the full transaction and the wallet signs only the user's own inputs. `kaspa:signPskt` takes a Safe-JSON transaction and an explicit `signInputs` list of `{ index, sighashType }` and returns the re-serialized signed transaction. A Safe-JSON transaction is the string produced by the WASM SDK's `Transaction.serializeToSafeJSON()`; wallets reconstruct it with `Transaction.deserializeFromSafeJSON()`.
+
+- The wallet **MUST** sign only the inputs listed in `signInputs` and **MUST** leave all other inputs untouched. Re-signing a covenant input corrupts the transaction.
+- The wallet **MUST** honor the requested `sighashType` (`1` = `SIGHASH_ALL`) and **MUST** refuse a type it does not implement rather than substitute another.
+- Before enabling `signPskt`, a wallet **SHOULD** test against a transaction containing both a covenant input and a user input — signing a plain send never exercises the "sign only these, leave the rest" requirement.
+
+The same discipline applies to PSKB signing (`kaspa:sign`): the wallet **MUST** only add signatures for inputs it owns and **MUST NOT** alter other entries of the bundle.
+
+### Network Identifiers
+
+Network ids are the node's own strings: `mainnet`, `testnet-10`, `testnet-11`, `devnet`. Some existing injected wallet APIs use `kaspa_`-prefixed variants (`kaspa_mainnet`, `kaspa_testnet_10`); adapters **SHOULD** normalize those to the canonical ids.
+
+### Errors
+
+Error payloads use the `KIP12ErrorPayload` shape above. Standard codes mirror EIP-1193 so integrators coming from EVM tooling get familiar values:
+
+- `4001` — user rejected the request
+- `4100` — origin not authorized (connect first)
+- `4200` — method not supported by this wallet
+- `4900` — wallet locked or unavailable
+
+A wallet **MUST** reject an unknown method with `4200` rather than silently ignoring it. Methods invoked through `request()` — including vendor-namespaced methods — are subject to the same connection requirement and the same signing rules as their typed counterparts.
+
+### Icons/Images
+The icon string **MUST** be a data URI as defined in [RFC-2397](https://datatracker.ietf.org/doc/html/rfc2397). The image **SHOULD** be a square with 96x96px minimum resolution. The image format is **RECOMMENDED** to be either lossless or vector-based such as PNG, WebP, or SVG to make the image easy to render on the Web App. Since SVG images can execute Javascript, applications and libraries **MUST** render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
+
+### Implementation Example
+
+```typescript
+export function script(providerInfo: ProviderInfo, extensionId: string, uuid: string) {
+    function generateUUID(): string {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            const r = crypto.getRandomValues(new Uint8Array(1))[0] & 15;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+
+    const kaspaProvider: KaspaProvider = {
+        request: async (method:string,args:any[]): Promise<any> => {
+            return new Promise((resolve, reject) => {
+                const eventId = generateUUID();
+
+                const message: Message = {
+                    eventId,
+                    extensionId,
+                    method,
+                    args
+                };
+
+                const handleResponse = (event: CustomEvent) => {
+                    const response = event.detail;
+                    if (response.method === "kaspa:event" &&
+                        response.eventId === eventId) {
+                        window.removeEventListener(uuid, handleResponse);
+                        if (response.error) {
+                            reject(response.error);
+                        } else {
+                            resolve(response.data?.data);
+                        }
+                    }
+                };
+                window.addEventListener(uuid, handleResponse);
+                window.dispatchEvent(new CustomEvent(uuid, { detail: message }));
+            });
+        },
+
+        connect: async (): Promise<void> => {
+            return new Promise((resolve, reject) => {
+                const eventId = generateUUID();
+
+                const message: Message = {
+                    eventId,
+                    extensionId,
+                    method: "kaspa:connect",
+                };
+
+                const handleResponse = (event: CustomEvent) => {
+                    const response = event.detail;
+                    if (response.method === "kaspa:event" &&
+                        response.eventId === eventId) {
+                        window.removeEventListener(uuid, handleResponse);
+                        if (response.error) {
+                            reject(response.error);
+                        } else {
+                            resolve();
+                        }
+                    }
+                };
+                window.addEventListener(uuid, handleResponse);
+                window.dispatchEvent(new CustomEvent(uuid, { detail: message }));
+            });
+        },
+
+        disconnect: async (): Promise<void> => {
+            const message: Message = {
+                eventId: generateUUID(),
+                extensionId,
+                method: "kaspa:disconnect"
+            };
+            window.dispatchEvent(new CustomEvent(uuid, { detail: message }));
+        }
+    };
+
+// Announce immediately on load, then respond to every request.
+// This covers the case where a dApp requests providers before
+// the extension has finished injecting.
+
+    const announce = () => {
+        window.dispatchEvent(new CustomEvent("kaspa:provider", {
+            detail: Object.freeze({
+                info: providerInfo,
+                provider: kaspaProvider
+            })
+        }));
+    };
+    window.addEventListener("kaspa:requestProvider", announce);
+    announce();
+// Listen for responses from the extension
+    window.addEventListener("message", (event: MessageEvent) => {
+// Handle events from the extension such as subscription events
+    });
+}
+```
+
+## Security Considerations
+
+- A provider announcement only means something is claiming to be a wallet. It doesn't prove the wallet's identity. Any page script can fire a `kaspa:provider` event with another wallet's `name` or `rdns`. The trust boundary is the wallet's own connect/sign prompt, which is shown by the extension, not the page.
+
+- A fake provider running in the page has no private keys and can't produce a valid signature. The real risk is UI spoofing or phishing, which is why every connection and signing request still requires explicit user approval.
+
+- Web apps **MUST** reject any icon that isn't a `data:` URL. Remote images introduce privacy and spoofing risks. Render wallet icons with `<img>` as described in [Icons/Images](#iconsimages).
+
+- Session restore is only a convenience for the UI. A web app **MAY** remember a wallet's `rdns` and restore the displayed account after a reload, but it **MUST** ask the user again before requesting a signature.
+
+- Wallets **MUST** keep authorization separate for each origin. One site **MUST NOT** be able to observe or reuse another site's authorization.
+
+- The signing rules in [Transaction Signing for Covenants](#transaction-signing-for-covenants-signpskt) are the main security property of this spec. If a wallet signs inputs it wasn't asked to sign, or changes sighash types, users can lose funds even if provider discovery works exactly as intended.
+
+
+## Notes for Earlier Implementations
+
+Implementations of earlier drafts of this document (and of the interim `kaspa-wallet-standard` package) map to this specification as follows:
+
+- `kaspa:announceProvider` (interim package) → `kaspa:provider`
+- `kaspa_mainnet` / `kaspa_testnet_10` network ids → `mainnet` / `testnet-10`
+- `networkChanged` event → `chainChanged`
+- required `window.kaspaProvider` global → removed; discovery via events
+- `kaspa:sendTransaction` with a float KAS `amount` → `amountSompi` base-10 string
+
+
+## Reference Implementations
+
+The handshake and provider interface described above have been exercised end to end against a production covenant dApp on testnet-10. Rift implements the full protocol and completed covenant trades through `signPskt` in both Chrome and Firefox; KasWare and Kastle completed the same trades in Chrome through their existing injected APIs behind dApp-side adapters.
+
+-  **Wallet implementation:** Rift, a browser extension implementing the provider events, typed interfaces, and `signPskt`, along with a companion [demo dApp](https://github.com/K-Kluster/kaspa-js/tree/master/apps/kip-12-dapp).
+
+-  **Web app implementation:** [`kaspa-wallet-standard`](https://www.npmjs.com/package/kaspa-wallet-standard), a zero-dependency TypeScript library that implements provider discovery, announcement handling, and receiver-side icon validation.
+
+-  **TypeScript definitions:** The interfaces referenced throughout this document are available in [`kip-0012/interfaces.ts`](kip-0012/interfaces.ts).
+
+
+
+
+## Acknowledgements
+
+The original draft of this KIP is by @aspect, @starkbamse, @KaffinPX, and @mattoo. @IzioDev proposed the message-signing and transaction-method amendments and built the Rift wallet that validated the transport. Thanks to Yura for input on the login and network-switching flows, and to the KSPR team for an early implementation of the original draft.

--- a/kip-0012.md
+++ b/kip-0012.md
@@ -16,10 +16,7 @@
 
 The Kaspa ecosystem is witnessing the emergence of several Browser Extension Wallet standards for interfacing with web applications. This KIP aims to standardize the methodology by which wallets expose themselves to and communicate with these web applications.
 
-Additionally, this KIP seeks to provide a common framework for wallets to showcase their capabilities, particularly in performing various functions and accommodating different emerging protocols. These protocols include, but are not limited to:
-
-- **KRC-20 protocol** by Kasplex
-- **KSC protocol** (future Sparkle Smart Contract assets)
+Additionally, this KIP seeks to provide a common framework for wallets to showcase their capabilities, particularly in performing various functions and accommodating different emerging protocols. These protocols include, but are not limited to, the KRC-20 protocol by Kasplex.
 
 Covenant transactions enabled by the Toccata upgrade add one more requirement: A wallet must be able to sign only the inputs it owns in a transaction built by the web app, without touching inputs that are authorized by on-chain rules. This document specifies that signing mode as well (see [Transaction Signing for Covenants](#transaction-signing-for-covenants-signpskt)).
 
@@ -265,7 +262,7 @@ The `detail` of a `kaspa:provider` event is `Object.freeze({ info, provider })`,
 
 Covenant transactions (post-Toccata) carry inputs that are authorized by on-chain rules rather than by the user's key, a bonding curve, a pool, a covenant-owned UTXO. The web app builds the full transaction and the wallet signs only the user's own inputs. `kaspa:signPskt` takes a Safe-JSON transaction and an explicit `signInputs` list of `{ index, sighashType }` and returns the re-serialized signed transaction. A Safe-JSON transaction is the string produced by the WASM SDK's `Transaction.serializeToSafeJSON()`; wallets reconstruct it with `Transaction.deserializeFromSafeJSON()`.
 
-- The wallet **MUST** sign only the inputs listed in `signInputs` and **MUST** leave all other inputs untouched. Re-signing a covenant input corrupts the transaction.
+- The wallet **MUST** sign only the inputs listed in `signInputs` and **MUST** leave all other inputs untouched. A covenant input's signature script is what authorizes the spend. Applying classic input signing to it overwrites that script, so the transaction fails verification.
 - The wallet **MUST** honor the requested `sighashType` (`1` = `SIGHASH_ALL`) and **MUST** refuse a type it does not implement rather than substitute another.
 - Before enabling `signPskt`, a wallet **SHOULD** test against a transaction containing both a covenant input and a user input — signing a plain send never exercises the "sign only these, leave the rest" requirement.
 
@@ -401,17 +398,6 @@ export function script(providerInfo: ProviderInfo, extensionId: string, uuid: st
 - Wallets **MUST** keep authorization separate for each origin. One site **MUST NOT** be able to observe or reuse another site's authorization.
 
 - The signing rules in [Transaction Signing for Covenants](#transaction-signing-for-covenants-signpskt) are the main security property of this spec. If a wallet signs inputs it wasn't asked to sign, or changes sighash types, users can lose funds even if provider discovery works exactly as intended.
-
-
-## Notes for Earlier Implementations
-
-Implementations of earlier drafts of this document (and of the interim `kaspa-wallet-standard` package) map to this specification as follows:
-
-- `kaspa:announceProvider` (interim package) → `kaspa:provider`
-- `kaspa_mainnet` / `kaspa_testnet_10` network ids → `mainnet` / `testnet-10`
-- `networkChanged` event → `chainChanged`
-- required `window.kaspaProvider` global → removed; discovery via events
-- `kaspa:sendTransaction` with a float KAS `amount` → `amountSompi` base-10 string
 
 
 ## Reference Implementations

--- a/kip-0012/interfaces.ts
+++ b/kip-0012/interfaces.ts
@@ -1,0 +1,241 @@
+/**
+ * KIP-12 — TypeScript interface definitions.
+ *
+ * Companion to ../kip-0012.md; these are the interfaces referenced throughout the
+ * specification. Zero dependencies; compiles standalone with `tsc --strict --noEmit`.
+ * Wallets copy the wallet-side pieces; web apps copy the app-side pieces.
+ */
+
+
+// Communication Events
+
+//Request wallets to announce themselves. Dispatched on `window` by the web app.
+export const KIP12_REQUEST_PROVIDER_EVENT = "kaspa:requestProvider" as const;
+
+//Announces the wallet's presence to the web app; `detail` is a frozen `KIP12ProviderDetail`.
+export const KIP12_PROVIDER_EVENT = "kaspa:provider" as const;
+
+// Used to send data from the wallet to the web app.
+export const KIP12_EVENT_METHOD = "kaspa:event" as const;
+
+export const KIP12_METHODS = [
+  "kaspa:connect",
+  "kaspa:disconnect",
+  "kaspa:requestAccounts",
+  "kaspa:chainId",
+  "kaspa:getPublicKey",
+  "kaspa:send",
+  "kaspa:sign",
+  "kaspa:broadcast",
+  "kaspa:signPersonal",
+  "kaspa:sendTransaction",
+  "kaspa:signTransaction",
+  "kaspa:broadcastTransaction",
+  "kaspa:signPskt",
+] as const;
+
+export type KIP12Method = (typeof KIP12_METHODS)[number];
+export type KIP12EventMethod = typeof KIP12_EVENT_METHOD;
+
+
+// Interface Definitions
+
+
+// Hex-encoded bytes / a serialized PSKB, as produced by the WASM SDK.
+export type HexString = string;
+export type PSKB = string;
+
+export interface KIP12ErrorPayload {
+  message: string;
+  code?: string | number;
+  details?: unknown;
+}
+
+
+// Amounts are encoded as base-10 sompi strings. Floating-point KAS values MUST
+// NOT be used on the wire because IEEE-754 can't represent every sompi value
+// exactly. Even a small rounding error can change the amount being signed.
+export interface KIP12SimpleTransfer {
+  to: string;
+  amountSompi: string;
+}
+
+// Describes an input the wallet should sign, identified by index.
+export interface KIP12SignInput {
+  index: number;
+  sighashType: number;
+}
+
+// `signPskt` argument: a Safe-JSON transaction plus the explicit list of inputs to sign.
+// A Safe-JSON transaction is the string produced by the WASM SDK's
+// `Transaction.serializeToSafeJSON()`; wallets reconstruct it with
+// `Transaction.deserializeFromSafeJSON()`.
+export interface KIP12SignPsktArg {
+  txJsonString: string;
+  options: { signInputs: KIP12SignInput[] };
+}
+
+export interface KIP12MethodArgs {
+  "kaspa:connect": [];
+  "kaspa:disconnect": [];
+  "kaspa:requestAccounts": [];
+  "kaspa:chainId": [];
+  "kaspa:getPublicKey": [];
+  "kaspa:send": [HexString];
+  "kaspa:sign": [PSKB];
+  "kaspa:broadcast": [HexString];
+  "kaspa:signPersonal": [string];
+  "kaspa:sendTransaction": [KIP12SimpleTransfer];
+  // safe JSON representation of the Transaction
+  "kaspa:signTransaction": [string];
+  "kaspa:broadcastTransaction": [HexString];
+  "kaspa:signPskt": [KIP12SignPsktArg];
+}
+
+export interface KIP12MethodResult {
+  "kaspa:connect": string;
+  "kaspa:disconnect": string;
+  // Returns array of addresses, no popup if already connected. A locked wallet
+  // MAY prompt the user to unlock, or reject with 4900.
+  "kaspa:requestAccounts": string[];
+  // Returns the current network identifier e.g. "mainnet" | "testnet-10" | "testnet-11"
+  "kaspa:chainId": string;
+  // Active account public key hex
+  "kaspa:getPublicKey": HexString;
+  "kaspa:send": HexString[];
+  "kaspa:sign": HexString;
+  "kaspa:broadcast": HexString;
+  "kaspa:signPersonal": HexString;
+  "kaspa:sendTransaction": HexString;
+  "kaspa:signTransaction": HexString;
+  "kaspa:broadcastTransaction": HexString;
+  // the re-serialized signed Safe-JSON transaction
+  "kaspa:signPskt": string;
+}
+
+export type KIP12Args<TMethod extends KIP12Method> = KIP12MethodArgs[TMethod];
+
+export type KIP12Result<TMethod extends KIP12Method> =
+  KIP12MethodResult[TMethod];
+
+export interface KIP12BaseMessage {
+  eventId: string;
+  extensionId?: string;
+}
+
+export interface KIP12RequestMessage<TMethod extends KIP12Method = KIP12Method>
+  extends KIP12BaseMessage {
+  method: TMethod;
+  args?: KIP12Args<TMethod>;
+}
+
+export interface KIP12EventSuccess<TData = unknown> extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data: TData;
+  error?: undefined;
+}
+
+export interface KIP12EventError extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data?: undefined;
+  error: KIP12ErrorPayload;
+}
+
+export type KIP12EventMessage<TData = unknown> =
+  | KIP12EventSuccess<TData>
+  | KIP12EventError;
+
+export type KIP12ExtensionMessage = KIP12RequestMessage | KIP12EventMessage;
+
+export interface KIP12ProviderInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly icon: string;
+  readonly methods: readonly KIP12Method[];
+  // UUIDv4, freshly generated per page load. Instance identity, used by web apps for dedupe.
+  readonly uuid: string;
+  // Reverse-DNS id, e.g. "com.kasware". STABLE across page loads; enables session restore.
+  readonly rdns?: string;
+}
+
+export interface KIP12Provider {
+// Core provider methods. Every provider implements `requestAccounts`.
+// Everything else is optional, so web apps should check for a method before
+// calling it (for example, `typeof provider.signPskt === "function"`).
+
+
+
+  requestAccounts(): Promise<string[]>;
+  getNetwork?(): Promise<string>;
+  getPublicKey?(): Promise<string>;
+  signMessage?(message: string): Promise<string>;
+  // Sign ONLY the listed inputs; all other inputs stay untouched.
+  signPskt?(arg: KIP12SignPsktArg): Promise<string>;
+  // Generic escape hatch for current and future protocol methods.
+  request?<TMethod extends KIP12Method>(
+    method: TMethod,
+    args: KIP12Args<TMethod>,
+  ): Promise<KIP12Result<TMethod>>;
+  connect?(): Promise<void>;
+  disconnect?(): Promise<void>;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  removeListener?(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+
+// Provider Info and Multi-Wallet Discovery
+
+
+// The `detail` of a `kaspa:provider` event is
+// `Object.freeze({ info, provider })`.
+//
+// Freezing the object prevents it from being modified after it's dispatched.
+// It does not verify who dispatched the event.
+
+
+
+export interface KIP12ProviderDetail {
+  readonly info: KIP12ProviderInfo;
+  readonly provider: KIP12Provider;
+}
+
+declare global {
+  interface WindowEventMap {
+    "kaspa:provider": CustomEvent<KIP12ProviderDetail>;
+    "kaspa:requestProvider": Event;
+  }
+}
+
+
+// Network Identifiers
+
+
+// Network ids are the node's own strings. Some existing injected wallet APIs use
+// `kaspa_`-prefixed variants (`kaspa_mainnet`, `kaspa_testnet_10`); adapters SHOULD
+// normalize those to the canonical ids.
+export const KIP12_NETWORKS = {
+  MAINNET: "mainnet",
+  TESTNET_10: "testnet-10",
+  TESTNET_11: "testnet-11",
+  DEVNET: "devnet",
+} as const;
+
+export type KIP12NetworkId = (typeof KIP12_NETWORKS)[keyof typeof KIP12_NETWORKS];
+
+
+// Errors
+
+
+// Standard codes mirror EIP-1193 so integrators coming from EVM tooling get familiar
+// values. A wallet MUST reject an unknown method with 4200 rather than silently
+// ignoring it.
+export const KIP12_ERRORS = {
+  //The user rejected the request.
+  USER_REJECTED: 4001,
+  //Origin not authorized (connect first).
+  UNAUTHORIZED: 4100,
+  //Method not supported by this wallet.
+  UNSUPPORTED_METHOD: 4200,
+  //Wallet locked or unavailable.
+  WALLET_UNAVAILABLE: 4900,
+} as const;


### PR DESCRIPTION
# KIP-12: Specification for Browser Extension Wallet APIs

Picks up the original KIP-12 draft (#21) where it left off. The original document is preserved and this PR incorporates the amendments that were already proposed and the changes that came out of implementing and testing the spec in real wallets and dApps.

## What changed vs #21

* **@IzioDev's amendments** (aspectron/kips#2) are included: The typed interface definitions along with `signPersonal`, `sendTransaction`, `signTransaction`, and `broadcastTransaction`.

* **Methods added during implementation:** `kaspa:requestAccounts` (connect + account list, similar to `eth_requestAccounts`), `kaspa:chainId`, `kaspa:getPublicKey`, and `kaspa:signPskt`, which lets a wallet sign only the requested inputs of a transaction built by the web app. Covenant dApps need this after Toccata, since wallets must leave covenant-authorized inputs untouched. The spec now defines the signing rules explicitly.

* **Multi-wallet discovery** was tightened up based on implementation experience. Wallets now announce on both page load and request, provider metadata includes `uuid` and `rdns` for deduplication and session restore, and the shared `window.kaspaProvider` global has been removed because it becomes last-write-wins when multiple wallets are installed. Wallets can still expose vendor-specific globals if they want to.

* **New sections** cover security considerations, standard error codes (matching EIP-1193's `4001`, `4100`, `4200`, and `4900`), and network identifiers (`mainnet`, `testnet-10`, etc.).

* Formal TypeScript interfaces are included alongside the specification in `kip-0012/interfaces.ts`.

## Validation

This isn't just a documentation update, the specification has been implemented and exercised end to end.

* **Three independently developed wallets**, KasWare, Kastle, and @IzioDev's Rift, successfully connected and completed trades against the production covenant dApp [KRON](https://kron.technology) on testnet-10. Rift did so through the announce/discovery handshake and required no wallet-specific code on the dApp side.

* **Chrome and Firefox** both work, with Rift covering Firefox's content-script/page compartment model.

* Covenant transactions, including token launches and bonding-curve buys and sells, were signed on-chain through `signPskt`. Those tests directly drove several parts of the specification, including announce-on-load, sompi string amounts, and the sighash validation rules.

* A zero-dependency reference implementation of the web app side is available on npm as [`kaspa-wallet-standard`](https://www.npmjs.com/package/kaspa-wallet-standard).

## Review

cc @aspect @KaffinPX @IzioDev @starkbamse.


